### PR TITLE
Added Moveit adapter package

### DIFF
--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   console_bridge
   moveit_core
   tf
+  cmake_modules
   descartes_trajectory_planning
 )
 

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -2,13 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(descartes_moveit)
 
 find_package(catkin REQUIRED COMPONENTS
-  console_bridge
   moveit_core
   tf
   cmake_modules
   descartes_trajectory_planning
 )
-
+find_package(console_bridge REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
 
@@ -20,9 +19,12 @@ catkin_package(
     descartes_moveit
   CATKIN_DEPENDS
     moveit_core
+    tf
+    cmake_modules
+    descartes_trajectory_planning
   DEPENDS
-    Boost
     console_bridge
+    Boost
     Eigen
 )
 

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(descartes_moveit)
+
+find_package(catkin REQUIRED COMPONENTS
+  console_bridge
+  moveit_core
+  tf
+  descartes_trajectory_planning
+)
+
+find_package(Boost REQUIRED)
+find_package(Eigen REQUIRED)
+
+
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    descartes_moveit
+  CATKIN_DEPENDS
+    moveit_core
+  DEPENDS
+    Boost
+    console_bridge
+    Eigen
+)
+
+###########
+## Build ##
+###########
+include_directories(include
+                    ${catkin_INCLUDE_DIRS}
+                    ${Boost_INCLUDE_DIRS}
+                    ${Eigen_INCLUDE_DIRS}
+)
+
+## Descartes MoveIt lib
+add_library(descartes_moveit
+            src/moveit_state_adapter.cpp
+)
+target_link_libraries(descartes_moveit
+                      ${catkin_LIBRARIES}
+)
+
+
+#############
+## Testing ##
+#############
+
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_descartes_trajectory_planning.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -1,0 +1,110 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MOVEIT_STATE_ADPATER_H_
+#define MOVEIT_STATE_ADPATER_H_
+
+#include "descartes_trajectory_planning/robot_model.h"
+#include "moveit/robot_model/robot_model.h"
+#include "moveit/kinematics_base/kinematics_base.h"
+#include <string>
+
+namespace descartes_moveit
+{
+
+/**@brief MoveitStateAdapter adapts the MoveIt RobotState to the Descartes RobotModel interface
+ *
+ */
+class MoveitStateAdapter : public descartes::RobotModel
+{
+public:
+
+  /**
+   * Constructor for Moveit state adapters (implements Descartes robot model interface)
+   * @param robot_state robot state object utilized for kinematic/dynamic state checking
+   * @param group_name planning group name
+   * @param tool_frame tool frame name
+   * @param wobj_frame work object frame name
+   */
+  MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
+                    const std::string & tool_frame, const std::string & wobj_frame);
+  virtual ~MoveitStateAdapter()
+  {
+  }
+  ;
+
+  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+                     std::vector<double> &joint_pose) const;
+
+  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
+
+  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const;
+
+  virtual bool isValid(const std::vector<double> &joint_pose) const;
+
+  virtual bool isValid(const Eigen::Affine3d &pose) const;
+
+protected:
+
+  /**
+   * @brief Default constructor hidden
+   */
+  MoveitStateAdapter()
+  {
+  }
+  ;
+
+  /**
+   * Gets IK solution (assumes robot state is pre-seeded)
+   * @param pose Affine pose of TOOL in WOBJ frame
+   * @param joint_pose Solution (if function successful).
+   * @return
+   */
+  bool getIK(const Eigen::Affine3d &pose, std::vector<double> &joint_pose) const;
+
+  /**
+   * @brief Pointer to moveit robot state (mutable object state is reset with
+   * each function call
+   */
+  mutable moveit::core::RobotStatePtr robot_state_;
+
+  /**
+   * @brief Planning group name
+   */
+  std::string group_name_;
+
+  /**
+   * @brief Tool frame name
+   */
+  std::string tool_base_;
+
+  /**
+   * @brief Work object/reference frame name
+   */
+  std::string wobj_base_;
+
+  /**
+   * @brief Joint solution sample iterations for returning "all" joints
+   */
+  size_t sample_iterations_;
+
+};
+
+} //descartes_moveit
+
+#endif /* MOVEIT_STATE_ADPATER_H_ */

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -42,7 +42,8 @@ public:
    * @param wobj_frame work object frame name
    */
   MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
-                    const std::string & tool_frame, const std::string & wobj_frame);
+                    const std::string & tool_frame, const std::string & wobj_frame,
+                     const size_t sample_iterations = 10);
   virtual ~MoveitStateAdapter()
   {
   }

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -45,10 +45,12 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>  descartes_trajectory_planning</build_depend>
   <run_depend>console_bridge</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>  descartes_trajectory_planning</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -44,9 +44,11 @@
   <build_depend>console_bridge</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <run_depend>console_bridge</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>cmake_modules</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<package>
+  <name>descartes_moveit</name>
+  <version>0.0.0</version>
+  <description>Moveit wrapper functions for descartes base types</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="Edwards@todo.todo">Shaun Edwards</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>Apache2</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/descartes_moveit</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+  <author >Shaun Edwards</author>
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>console_bridge</build_depend>
+  <build_depend>moveit_core</build_depend>
+  <build_depend>tf</build_depend>
+  <run_depend>console_bridge</run_depend>
+  <run_depend>moveit_core</run_depend>
+  <run_depend>tf</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -1,0 +1,180 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <console_bridge/console.h>
+#include "descartes_moveit/moveit_state_adapter.h"
+#include "eigen_conversions/eigen_msg.h"
+#include "random_numbers/random_numbers.h"
+#include "descartes_trajectory_planning/pretty_print.hpp"
+#include <sstream>
+
+#define NOT_IMPLEMENTED_ERR logError("%s not implemented", __PRETTY_FUNCTION__)
+
+namespace descartes_moveit
+{
+
+MoveitStateAdapter::MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
+                                     const std::string & tool_frame, const std::string & wobj_frame) :
+    robot_state_(new moveit::core::RobotState(robot_state)), group_name_(group_name),
+    tool_base_(tool_frame), wobj_base_(wobj_frame)
+{
+
+  moveit::core::RobotModelConstPtr robot_model_ = robot_state_->getRobotModel();
+
+  if (robot_model_->hasJointModel(group_name_))
+  {
+    std::vector<std::string> joint_names = robot_model_->getJointModelGroup(group_name_)->getJointModelNames();
+    if (tool_base_ != joint_names.back())
+    {
+      logError("Tool: %s does not match group tool: %s, functionality will be implemented in the future",
+               tool_base_.c_str(), joint_names.front().c_str());
+    }
+    if (wobj_base_ != joint_names.back())
+    {
+      logError("Work object: %s does not match group base: %s, functionality will be implemented in the future",
+               wobj_base_.c_str(), joint_names.back().c_str());
+    }
+  }
+  else
+  {
+    logError("Joint group: %s does not exist in robot model");
+  }
+  return;
+}
+
+bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+                              std::vector<double> &joint_pose) const
+{
+  robot_state_->setJointGroupPositions(group_name_, seed_state);
+  return getIK(pose, joint_pose);
+}
+
+bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, std::vector<double> &joint_pose) const
+{
+  bool rtn = false;
+  if (robot_state_->setFromIK(robot_state_->getJointModelGroup(group_name_), pose, tool_base_))
+  {
+    joint_pose.resize(robot_state_->getVariableCount());
+    for (size_t ii = 0; ii < robot_state_->getVariableCount(); ++ii)
+    {
+      joint_pose[ii] = robot_state_->getVariablePosition(ii);
+    }
+    rtn = true;
+  }
+  else
+  {
+    logError("Could not set Cartesian pose.");
+    rtn = false;
+  }
+  return rtn;
+}
+
+bool MoveitStateAdapter::getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const
+{
+  joint_poses.clear();
+  for (size_t sample_iter = 0; sample_iter < sample_iterations_; ++sample_iter)
+  {
+    robot_state_->setToRandomPositions();
+    std::vector<double> joint_pose;
+    if (getIK(pose, joint_pose))
+    {
+      std::vector<std::vector<double> >::iterator it;
+
+      it = find(joint_poses.begin(), joint_poses.end(), joint_pose);
+      if (it == joint_poses.end())
+      {
+        std::stringstream msg;
+        msg << "Found *new* solution on " << sample_iter << " iteration, joint: " << *it;
+        logDebug(msg.str().c_str());
+        joint_poses.push_back(joint_pose);
+      }
+    }
+  }
+  logDebug("Found %d joint solutions out of %d iterations", joint_poses.size(), sample_iterations_);
+  if (joint_poses.empty())
+  {
+    return false;
+  }
+  else
+  {
+    return true;
+  }
+}
+
+bool MoveitStateAdapter::getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const
+{
+  bool rtn = false;
+  robot_state_->setVariablePositions(joint_pose);
+  if ( isValid(joint_pose) )
+  {
+  if (robot_state_->knowsFrameTransform(tool_base_))
+  {
+    pose = robot_state_->getFrameTransform(tool_base_);
+    rtn = true;
+  }
+  else
+  {
+    logError("Robot state does not recognize tool frame: %s", tool_base_.c_str());
+    rtn = false;
+  }
+  }
+  else
+  {
+    logError("Invalid joint pose passed to get forward kinematics");
+    rtn = false;
+  }
+  return rtn;
+}
+
+bool MoveitStateAdapter::isValid(const std::vector<double> &joint_pose) const
+{
+  bool rtn = false;
+  if (robot_state_->getVariableCount() == joint_pose.size())
+  {
+    robot_state_->setVariablePositions(joint_pose);
+    robot_state_->setVariableVelocities(std::vector<double>(joint_pose.size(), 0.));
+    robot_state_->setVariableAccelerations(std::vector<double>(joint_pose.size(), 0.));
+    if (robot_state_->satisfiesBounds())
+    {
+      rtn = true;
+    }
+    else
+    {
+      std::stringstream msg;
+      msg << "Joint pose: " << joint_pose << ", outside joint boundaries";
+      logDebug(msg.str().c_str());
+    }
+  }
+  else
+  {
+    logError("Size of joint pose: %d doesn't match robot state variable size: %d",
+             joint_pose.size(), robot_state_->getVariableCount());
+    rtn = false;
+  }
+  return rtn;
+}
+
+bool MoveitStateAdapter::isValid(const Eigen::Affine3d &pose) const
+{
+  //TODO: Could check robot extents first as a quick check
+  std::vector<double> dummy;
+  return getIK(pose, dummy);
+}
+
+} //descartes_moveit
+

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -170,7 +170,9 @@ bool MoveitStateAdapter::getFK(const std::vector<double> &joint_pose, Eigen::Aff
 bool MoveitStateAdapter::isValid(const std::vector<double> &joint_pose) const
 {
   bool rtn = false;
-  if (robot_state_->getVariableCount() == joint_pose.size())
+
+  if (robot_state_->getJointModelGroup(group_name_)->getJointModels().size() ==
+      joint_pose.size())
   {
     robot_state_->setJointGroupPositions(group_name_, joint_pose);
     //TODO: At some point velocities and accelerations should be set for the group as

--- a/descartes_trajectory_planning/include/descartes_trajectory_planning/pretty_print.hpp
+++ b/descartes_trajectory_planning/include/descartes_trajectory_planning/pretty_print.hpp
@@ -1,0 +1,410 @@
+//          Copyright Louis Delacroix 2010 - 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+// Original source code found here: https://github.com/louisdx/cxx-prettyprint
+
+#ifndef H_PRETTY_PRINT
+#define H_PRETTY_PRINT
+
+
+#include <ostream>
+#include <utility>
+#include <iterator>
+#include <set>
+
+#ifndef NO_TR1
+#  include <tr1/tuple>
+#  include <tr1/unordered_set>
+#endif
+
+namespace pretty_print
+{
+
+    template <bool, typename S, typename T> struct conditional { };
+    template <typename S, typename T> struct conditional<true,  S, T> { typedef S type; };
+    template <typename S, typename T> struct conditional<false, S, T> { typedef T type; };
+
+    template <bool, typename T> struct enable_if { };
+    template <typename T> struct enable_if<true, T> { typedef T type; };
+
+    // SFINAE type trait to detect whether T::const_iterator exists.
+
+    template<typename T>
+    struct has_const_iterator
+    {
+    private:
+        typedef char                      yes;
+        typedef struct { char array[2]; } no;
+
+        template<typename C> static yes test(typename C::const_iterator*);
+        template<typename C> static no  test(...);
+    public:
+        static const bool value = sizeof(test<T>(0)) == sizeof(yes);
+        typedef T type;
+    };
+
+    // SFINAE type trait to detect whether "T::const_iterator T::begin/end() const" exist.
+
+    template <typename T>
+    struct has_begin_end
+    {
+        struct Dummy { typedef void const_iterator; };
+        typedef typename conditional<has_const_iterator<T>::value, T, Dummy>::type TType;
+        typedef typename TType::const_iterator iter;
+
+        struct Fallback { iter begin() const; iter end() const; };
+        struct Derived : TType, Fallback { };
+
+        template<typename C, C> struct ChT;
+
+        template<typename C> static char (&f(ChT<iter (Fallback::*)() const, &C::begin>*))[1];
+        template<typename C> static char (&f(...))[2];
+        template<typename C> static char (&g(ChT<iter (Fallback::*)() const, &C::end>*))[1];
+        template<typename C> static char (&g(...))[2];
+
+        static bool const beg_value = sizeof(f<Derived>(0)) == 2;
+        static bool const end_value = sizeof(g<Derived>(0)) == 2;
+    };
+
+    // Basic is_container template; specialize to have value "true" for all desired container types
+
+    template<typename T> struct is_container { static const bool value = has_const_iterator<T>::value && has_begin_end<T>::beg_value && has_begin_end<T>::end_value; };
+
+    template<typename T, std::size_t N> struct is_container<T[N]> { static const bool value = true; };
+
+    template<std::size_t N> struct is_container<char[N]> { static const bool value = false; };
+
+
+    // Holds the delimiter values for a specific character type
+
+    template<typename TChar>
+    struct delimiters_values
+    {
+        typedef TChar char_type;
+        const TChar * prefix;
+        const TChar * delimiter;
+        const TChar * postfix;
+    };
+
+
+    // Defines the delimiter values for a specific container and character type
+
+    template<typename T, typename TChar>
+    struct delimiters
+    {
+        typedef delimiters_values<TChar> type;
+        static const type values;
+    };
+
+
+    // Default delimiters
+
+    template<typename T> struct delimiters<T, char> { static const delimiters_values<char> values; };
+    template<typename T> const delimiters_values<char> delimiters<T, char>::values = { "[", ", ", "]" };
+    template<typename T> struct delimiters<T, wchar_t> { static const delimiters_values<wchar_t> values; };
+    template<typename T> const delimiters_values<wchar_t> delimiters<T, wchar_t>::values = { L"[", L", ", L"]" };
+
+
+    // Delimiters for (multi)set and unordered_(multi)set
+
+    template<typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::set<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template<typename T, typename TComp, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::set<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template<typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::set<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template<typename T, typename TComp, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::set<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+    template<typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::multiset<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template<typename T, typename TComp, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::multiset<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template<typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template<typename T, typename TComp, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+#ifndef NO_TR1
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::tr1::unordered_set<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::tr1::unordered_set<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::tr1::unordered_set<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::tr1::unordered_set<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::tr1::unordered_multiset<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::tr1::unordered_multiset<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::tr1::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template<typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::tr1::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+#endif
+
+
+    // Delimiters for pair (reused for tuple, see below)
+
+    template<typename T1, typename T2> struct delimiters< ::std::pair<T1, T2>, char> { static const delimiters_values<char> values; };
+    template<typename T1, typename T2> const delimiters_values<char> delimiters< ::std::pair<T1, T2>, char>::values = { "(", ", ", ")" };
+    template<typename T1, typename T2> struct delimiters< ::std::pair<T1, T2>, wchar_t> { static const delimiters_values<wchar_t> values; };
+    template<typename T1, typename T2> const delimiters_values<wchar_t> delimiters< ::std::pair<T1, T2>, wchar_t>::values = { L"(", L", ", L")" };
+
+
+    // Iterator microtrait class to handle C arrays uniformly
+
+    template <typename T> struct get_iterator { typedef typename T::const_iterator iter; };
+    template <typename T, std::size_t N> struct get_iterator<T[N]> { typedef const T * iter; };
+
+    template <typename T> typename enable_if<has_const_iterator<T>::value, typename T::const_iterator>::type begin(const T & c) { return c.begin(); }
+    template <typename T> typename enable_if<has_const_iterator<T>::value, typename T::const_iterator>::type end(const T & c) { return c.end(); }
+    template <typename T, size_t N> const T * begin(const T(&x)[N]) { return &x[0];     }
+    template <typename T, size_t N> const T * end  (const T(&x)[N]) { return &x[0] + N; }
+
+    // Functor to print containers. You can use this directly if you want to specificy a non-default delimiters type.
+
+    template<typename T, typename TChar = char, typename TCharTraits = ::std::char_traits<TChar>, typename TDelimiters = delimiters<T, TChar> >
+    struct print_container_helper
+    {
+        typedef TChar char_type;
+        typedef TDelimiters delimiters_type;
+        typedef std::basic_ostream<TChar, TCharTraits> ostream_type;
+        typedef typename get_iterator<T>::iter TIter;
+
+        print_container_helper(const T & container)
+        : _container(container)
+        {
+        }
+
+        inline void operator()(ostream_type & stream) const
+        {
+            if (delimiters_type::values.prefix != NULL)
+                stream << delimiters_type::values.prefix;
+
+            if (begin(_container) != end(_container))
+            for (TIter it = begin(_container), it_end = end(_container); ; )
+            {
+                stream << *it;
+
+                if (++it == it_end) break;
+
+                if (delimiters_type::values.delimiter != NULL)
+                    stream << delimiters_type::values.delimiter;
+            }
+
+            if (delimiters_type::values.postfix != NULL)
+                stream << delimiters_type::values.postfix;
+        }
+
+    private:
+        const T & _container;
+    };
+
+
+    // Type-erasing helper class for easy use of custom delimiters.
+    // Requires TCharTraits = std::char_traits<TChar> and TChar = char or wchar_t, and MyDelims needs to be defined for TChar.
+    // Usage: "cout << pretty_print::custom_delims<MyDelims>(x)".
+
+    struct custom_delims_base
+    {
+        virtual ~custom_delims_base() { }
+        virtual ::std::ostream & stream(::std::ostream &) = 0;
+        virtual ::std::wostream & stream(::std::wostream &) = 0;
+    };
+
+    template<typename T, typename Delims>
+    struct custom_delims_wrapper : public custom_delims_base
+    {
+        custom_delims_wrapper(const T & t_) : t(t_) { }
+
+        ::std::ostream & stream(::std::ostream & s)
+        {
+          return s << ::pretty_print::print_container_helper<T, char, ::std::char_traits<char>, Delims>(t);
+        }
+        ::std::wostream & stream(::std::wostream & s)
+        {
+          return s << ::pretty_print::print_container_helper<T, wchar_t, ::std::char_traits<wchar_t>, Delims>(t);
+        }
+
+    private:
+        const T & t;
+    };
+
+    template<typename Delims>
+    struct custom_delims
+    {
+        template<typename Container> custom_delims(const Container & c) : base(new custom_delims_wrapper<Container, Delims>(c)) { }
+        ~custom_delims() { delete base; }
+        custom_delims_base * base;
+    };
+
+} // namespace pretty_print
+
+template<typename TChar, typename TCharTraits, typename Delims>
+inline std::basic_ostream<TChar, TCharTraits> & operator<<(std::basic_ostream<TChar, TCharTraits> & s, const pretty_print::custom_delims<Delims> & p)
+{
+    return p.base->stream(s);
+}
+
+// Template aliases for char and wchar_t delimiters
+// Enable these if you have compiler support
+//
+// Implement as "template<T, C, A> const sdelims::type sdelims<std::set<T,C,A>>::values = { ... }."
+
+//template<typename T> using pp_sdelims = pretty_print::delimiters<T, char>;
+//template<typename T> using pp_wsdelims = pretty_print::delimiters<T, wchar_t>;
+
+
+namespace std
+{
+    // Prints a print_container_helper to the specified stream.
+
+    template<typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+    inline basic_ostream<TChar, TCharTraits> & operator<<(basic_ostream<TChar, TCharTraits> & stream,
+                                                          const ::pretty_print::print_container_helper<T, TChar, TCharTraits, TDelimiters> & helper)
+    {
+        helper(stream);
+        return stream;
+    }
+
+    // Prints a container to the stream using default delimiters
+
+    template<typename T, typename TChar, typename TCharTraits>
+    inline typename ::pretty_print::enable_if< ::pretty_print::is_container<T>::value, basic_ostream<TChar, TCharTraits>&>::type
+    operator<<(basic_ostream<TChar, TCharTraits> & stream, const T & container)
+    {
+        return stream << ::pretty_print::print_container_helper<T, TChar, TCharTraits>(container);
+    }
+
+    // Prints a pair to the stream using delimiters from delimiters<std::pair<T1, T2>>.
+    template<typename T1, typename T2, typename TChar, typename TCharTraits>
+    inline basic_ostream<TChar, TCharTraits> & operator<<(basic_ostream<TChar, TCharTraits> & stream, const pair<T1, T2> & value)
+    {
+        if (::pretty_print::delimiters<pair<T1, T2>, TChar>::values.prefix != NULL)
+            stream << ::pretty_print::delimiters<pair<T1, T2>, TChar>::values.prefix;
+
+        stream << value.first;
+
+        if (::pretty_print::delimiters<pair<T1, T2>, TChar>::values.delimiter != NULL)
+            stream << ::pretty_print::delimiters<pair<T1, T2>, TChar>::values.delimiter;
+
+        stream << value.second;
+
+        if (::pretty_print::delimiters<pair<T1, T2>, TChar>::values.postfix != NULL)
+            stream << ::pretty_print::delimiters<pair<T1, T2>, TChar>::values.postfix;
+
+        return stream;
+    }
+} // namespace std
+
+
+#ifndef NO_TR1
+
+// Prints a tuple to the stream using delimiters from delimiters<std::pair<tuple_dummy_t, tuple_dummy_t>>.
+
+namespace pretty_print
+{
+    struct tuple_dummy_t { }; // Just if you want special delimiters for tuples.
+
+    typedef std::pair<tuple_dummy_t, tuple_dummy_t> tuple_dummy_pair;
+
+    template<typename Tuple, size_t N, typename TChar, typename TCharTraits>
+    struct pretty_tuple_helper
+    {
+        static inline void print(::std::basic_ostream<TChar, TCharTraits> & stream, const Tuple & value)
+        {
+            pretty_tuple_helper<Tuple, N - 1, TChar, TCharTraits>::print(stream, value);
+
+            if (delimiters<tuple_dummy_pair, TChar>::values.delimiter != NULL)
+                stream << delimiters<tuple_dummy_pair, TChar>::values.delimiter;
+
+            stream << std::tr1::get<N - 1>(value);
+        }
+    };
+
+    template<typename Tuple, typename TChar, typename TCharTraits>
+    struct pretty_tuple_helper<Tuple, 1, TChar, TCharTraits>
+    {
+        static inline void print(::std::basic_ostream<TChar, TCharTraits> & stream, const Tuple & value)
+        {
+            stream << ::std::tr1::get<0>(value);
+        }
+    };
+} // namespace pretty_print
+
+
+/* The following macros allow us to write "template <TUPLE_PARAMAS> std::tuple<TUPLE_ARGS>"
+ * uniformly in C++0x compilers and in MS Visual Studio 2010.
+ * Credits to STL: http://channel9.msdn.com/Shows/Going+Deep/C9-Lectures-Stephan-T-Lavavej-Advanced-STL-6-of-n
+ */
+
+#define TUPLE_PARAMS \
+    typename T0, typename T1, typename T2, typename T3, typename T4,      \
+    typename T5, typename T6, typename T7, typename T8, typename T9
+#define TUPLE_ARGS T0, T1, T2, T3, T4, T5, T6, T7, T8, T9
+
+
+namespace std
+{
+    template<typename TChar, typename TCharTraits, TUPLE_PARAMS>
+    inline basic_ostream<TChar, TCharTraits> & operator<<(basic_ostream<TChar, TCharTraits> & stream, const tr1::tuple<TUPLE_ARGS> & value)
+    {
+        if (::pretty_print::delimiters< ::pretty_print::tuple_dummy_pair, TChar>::values.prefix != NULL)
+            stream << ::pretty_print::delimiters< ::pretty_print::tuple_dummy_pair, TChar>::values.prefix;
+
+        ::pretty_print::pretty_tuple_helper<const tr1::tuple<TUPLE_ARGS> &, tr1::tuple_size<tr1::tuple<TUPLE_ARGS> >::value, TChar, TCharTraits>::print(stream, value);
+
+        if (::pretty_print::delimiters< ::pretty_print::tuple_dummy_pair, TChar>::values.postfix != NULL)
+            stream << ::pretty_print::delimiters< ::pretty_print::tuple_dummy_pair, TChar>::values.postfix;
+
+        return stream;
+    }
+} // namespace std
+
+#endif // NO_TR1
+
+
+// A wrapper for raw C-style arrays. Usage: int arr[] = { 1, 2, 4, 8, 16 };  std::cout << wrap_array(arr) << ...
+
+namespace pretty_print
+{
+    template<typename T>
+    struct array_wrapper_n
+    {
+        typedef const T * const_iterator;
+        typedef T value_type;
+
+        array_wrapper_n(const T * const a, size_t n) : _array(a), _n(n) { }
+        inline const_iterator begin() const { return _array; }
+        inline const_iterator end() const { return _array + _n; }
+
+    private:
+        const T * const _array;
+        size_t _n;
+    };
+} // namespace pretty_print
+
+template<typename T>
+inline pretty_print::array_wrapper_n<T> pretty_print_array(const T * const a, size_t n)
+{
+  return pretty_print::array_wrapper_n<T>(a, n);
+}
+
+
+#endif

--- a/descartes_trajectory_planning/include/descartes_trajectory_planning/robot_model.h
+++ b/descartes_trajectory_planning/include/descartes_trajectory_planning/robot_model.h
@@ -19,6 +19,8 @@
 #ifndef ROBOT_KINEMATICS_H_
 #define ROBOT_KINEMATICS_H_
 
+//TODO: The include below picks up Eigen::Affine3d, but there is probably a better way
+#include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include "descartes_trajectory_planning/utils.h"
 
 namespace descartes
@@ -65,7 +67,7 @@ public:
    * @param joint_poses Solution (if function successful).
    * @return True if successful
    */
-  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
+  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const = 0;
 
   /**
    * @brief Returns the affine pose


### PR DESCRIPTION
This implements the Descartes `RobotModel` interface for MoveIt.  The PR includes some parts of PR #13, but not all.  Method implementations for `TrajectoryPt` are not included.  However, these methods will simply be wrappers around RobotModel calls when required.
