### PR TITLE
Initial implementation of JointTrajectoryPtDefaultSampler

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(descartes_core
             src/joint_trajectory_pt.cpp
             src/trajectory.cpp
             src/planning_graph.cpp
+            src/samplers/joint_trajectory_pt_default_sampler.cpp
 )
 ##Disabling planning graph due to issues with
 ##Trajectory point ID
@@ -60,7 +61,9 @@ if(CATKIN_ENABLE_TESTING)
   set(UTEST_SRC_FILES test/utest.cpp
       test/trajectory_pt.cpp
       test/cart_trajectory_pt.cpp
-      test/joint_trajectory_pt.cpp)
+      test/joint_trajectory_pt.cpp
+      test/test_joint_trajectory_pt_default_sampler.cpp
+  )
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
 endif()

--- a/descartes_core/include/descartes_core/cart_trajectory_pt.h
+++ b/descartes_core/include/descartes_core/cart_trajectory_pt.h
@@ -97,6 +97,27 @@ class CartTrajectoryPt : public TrajectoryPt
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+
+public:
+  struct CartPointData
+  {
+    CartPointData():
+      wobj_base(Eigen::Affine3d::Identity()), wobj_pt(Eigen::Affine3d::Identity()),
+      tool_base(Eigen::Affine3d::Identity()), tool_pt(Eigen::Affine3d::Identity())
+    {};
+
+    CartPointData(const Frame &_wobj_base, const TolerancedFrame &_wobj_pt,
+                  const Frame &_tool_base, const TolerancedFrame &_tool_pt):
+                    wobj_base(_wobj_base), wobj_pt(_wobj_pt),
+                    tool_base(_tool_base), tool_pt(_tool_pt)
+    {};
+
+    Frame               tool_base;      /**<@brief Fixed transform from wrist/tool_plate to tool base. */
+    TolerancedFrame     tool_pt;        /**<@brief Underconstrained transform from tool_base to effective pt on tool. */
+    Frame               wobj_base;      /**<@brief Fixed transform from WCS to base of object. */
+    TolerancedFrame     wobj_pt;        /**<@brief Underconstrained transform from object base to goal point on object. */
+  };
+
 public:
 
   /**
@@ -172,33 +193,32 @@ public:
 
     //TODO complete
     virtual bool isValid(const RobotModel &model) const;
-  /**@brief Set discretization. Cartesian points can have position and angular discretization.
-   * @param discretization Vector of discretization values. Must be length 2 or 6 (position/orientation or separate xyzrpy).
-   * @return True if vector is valid length/values. TODO what are valid values?
-   */
-  virtual bool setDiscretization(const std::vector<double> &discretization);
 
   inline
   void setTool(const Frame &base, const TolerancedFrame &pt)
   {
-    tool_base_ = base;
-    tool_pt_ = pt;
+    point_data_.tool_base = base;
+    point_data_.tool_pt = pt;
   }
 
   inline
   void setWobj(const Frame &base, const TolerancedFrame &pt)
   {
-    wobj_base_ = base;
-    wobj_pt_ = pt;
+    point_data_.wobj_base = base;
+    point_data_.wobj_pt = pt;
   }
 
+  virtual const void* getPointData() const;
+
+  virtual
+  bool setSampler(const TrajectoryPtSamplerPtr &sampler);
+
+  virtual
+  bool sample(size_t n);
 
 protected:
-  Frame                         tool_base_;     /**<@brief Fixed transform from wrist/tool_plate to tool base. */
-  TolerancedFrame               tool_pt_;       /**<@brief Underconstrained transform from tool_base to effective pt on tool. */
-  Frame                         wobj_base_;     /**<@brief Fixed transform from WCS to base of object. */
-  TolerancedFrame               wobj_pt_;       /**<@brief Underconstrained transform from object base to goal point on object. */
 
+  CartPointData point_data_;
 
 };
 

--- a/descartes_core/include/descartes_core/joint_trajectory_pt.h
+++ b/descartes_core/include/descartes_core/joint_trajectory_pt.h
@@ -86,6 +86,25 @@ class JointTrajectoryPt: public TrajectoryPt
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;      //TODO is this needed when Frame already has it?
+
+public:
+  struct JointPointData
+  {
+    JointPointData():
+      tool(Eigen::Affine3d::Identity()), wobj(Eigen::Affine3d::Identity())
+    {};
+
+    JointPointData(const std::vector<TolerancedJointValue> &_joints,
+                   const Frame &_tool, const Frame &_wobj):
+                     joint_position(_joints),
+                     tool(_tool), wobj(_wobj)
+    {};
+
+    std::vector<TolerancedJointValue> joint_position;   /**<@brief Fixed joint position with tolerance */
+    Frame tool;                                         /**<@brief Transform from robot wrist to active tool pt. */
+    Frame wobj;                                         /**<@brief Transform from world to active workobject pt. */
+  };
+
 public:
   /**
     @brief Default joint trajectory point constructor.  All frames initialized to Identity, joint
@@ -146,6 +165,8 @@ public:
                                      const RobotModel &model,
                                      std::vector<double> &joint_pose) const;
 
+  virtual const void* getPointData() const;
+
   //TODO complete
   virtual void getJointPoses(const RobotModel &model,
                                std::vector<std::vector<double> > &joint_poses) const;
@@ -154,41 +175,34 @@ public:
   //TODO complete
   virtual bool isValid(const RobotModel &model) const;
 
-  //TODO complete
-  /**@brief Set discretization. Each joint can have a different discretization.
-   * @param discretization Vector of discretization values. If length=1, set all elements of discretization_ are set to value.
-   * @return True if vector is length 1 or length(joint_position_) and value[ii] are within 0-range(joint_position[ii]).
-   */
-  virtual bool setDiscretization(const std::vector<double> &discretization);
-
 inline
   void setJoints(const std::vector<TolerancedJointValue> &joints)
   {
-    joint_position_ = joints;
+    point_data_.joint_position = joints;
   }
 
   inline
   void setTool(const Frame &tool)
   {
-    tool_ = tool;
+    point_data_.tool = tool;
   }
 
   inline
   void setWobj(const Frame &wobj)
   {
-    wobj_ = wobj;
+    point_data_.wobj = wobj;
   }
   /**@} (end Setters section) */
-protected:
-  std::vector<TolerancedJointValue> joint_position_;  /**<@brief Fixed joint position with tolerance */
-  std::vector<double>               discretization_;  /**<@brief How finely to discretize each joint */
 
-  /** @name JointTrajectoryPt transforms. Used in get*CartPose() methods and for interpolation.
-   *  @{
-   */
-  Frame                         tool_;                  /**<@brief Transform from robot wrist to active tool pt. */
-  Frame                         wobj_;                  /**<@brief Transform from world to active workobject pt. */
-  /** @} (end section) */
+  virtual
+  bool setSampler(const TrajectoryPtSamplerPtr &sampler);
+
+  virtual
+  bool sample(size_t n);
+
+protected:
+
+  JointPointData point_data_;
 
 };
 

--- a/descartes_core/include/descartes_core/samplers/joint_trajectory_pt_default_sampler.h
+++ b/descartes_core/include/descartes_core/samplers/joint_trajectory_pt_default_sampler.h
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * trajectory_pt_sampler.h
+ *
+ *  Created on: Oct 29, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_
+#define JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_
+
+#include <descartes_core/samplers/trajectory_pt_sampler.h>
+#include <descartes_core/joint_trajectory_pt.h>
+
+
+namespace descartes_core
+{
+
+class JointTrajectoryPtDefaultSampler : public TrajectoryPtSampler
+{
+public:
+  typedef std::vector<std::vector<double> > SampleData;
+
+public:
+  virtual ~JointTrajectoryPtDefaultSampler();
+
+  inline virtual
+  std::vector<double> getDiscretization() const
+  {
+    return discretization_;
+  }
+  inline virtual
+  void setDiscretization(const std::vector<double> &values)
+  {
+    discretization_ = values;
+  }
+
+  virtual
+  bool init(const TrajectoryPt &pt);
+
+  virtual
+  const void* sample(size_t n, const TrajectoryPt &pt);
+
+protected:
+
+  struct SamplerState
+  {
+    typedef std::vector<double> JointSample;
+    std::vector<JointSample> samples;
+    std::vector<size_t> sample_idx;
+    bool done;
+
+    JointSample current_sample();
+
+    void clear()
+    {
+      samples.clear();
+      sample_idx.clear();
+      done = false;
+    }
+
+    /* prefix */
+    SamplerState& operator++ ();
+
+    /* postfix */
+    SamplerState operator++ (int)
+    {
+      SamplerState tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+  };
+
+  /* Private Members */
+  std::vector<double> discretization_;
+  SamplerState sampler_state_;
+
+private:
+
+  SampleData solution_storage_;  /**<@brief storage for solutions created by sample() */
+
+};
+
+} /* namespace descartes_core */
+
+#endif /* JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_ */

--- a/descartes_core/include/descartes_core/samplers/trajectory_pt_sampler.h
+++ b/descartes_core/include/descartes_core/samplers/trajectory_pt_sampler.h
@@ -1,0 +1,67 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * trajectory_pt_sampler.h
+ *
+ *  Created on: Oct 29, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef TRAJECTORY_PT_SAMPLER_H_
+#define TRAJECTORY_PT_SAMPLER_H_
+
+#include <descartes_core/trajectory_pt.h>
+#include <descartes_core/utils.h>
+#include <sensor_msgs/JointState.h>
+
+
+namespace descartes_core
+{
+
+DESCARTES_CLASS_FORWARD(TrajectoryPtSampler);
+DESCARTES_CLASS_FORWARD(TrajectoryPt);
+
+class TrajectoryPtSampler
+{
+public:
+  TrajectoryPtSampler() {};
+  virtual ~TrajectoryPtSampler() {};
+
+  /**@brief Initialize sampler data for @e pt
+   * @param pt TrajectoryPt being initialized.
+   */
+  virtual
+  bool init(const TrajectoryPt &pt) = 0;
+
+  /**@brief Return joint solutions that satisfy a TrajectoryPt.
+   *
+   * Subsequent calls to this function return more solutions (if they remain. If sampler is complete, will return false).
+   *
+   * @param[out] solutions vector of JointStates.
+   * @param[in] n Number of samples to perform (not necessarily equal to number of solutions returned). n=0 means get all remaining solutions.
+   * @param[in] pt TrajectoryPt to sample from.
+   * @return True if new solutions were successfully created.
+   */
+  virtual
+  const void* sample(size_t n, const TrajectoryPt &pt) = 0;
+
+};
+
+} /* namespace descartes_core */
+
+#endif /* TRAJECTORY_PT_SAMPLER_H_ */

--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -33,11 +33,16 @@
 #include <boost/uuid/uuid_generators.hpp>
 
 #include "descartes_core/robot_model.h"
+#include "descartes_core/samplers/trajectory_pt_sampler.h"
 #include "descartes_core/trajectory_pt_transition.h"
+#include "descartes_core/utils.h"
 
 
 namespace descartes_core
 {
+
+DESCARTES_CLASS_FORWARD(TrajectoryPt);
+DESCARTES_CLASS_FORWARD(TrajectoryPtSampler);
 
 /**@brief Frame is a wrapper for an affine frame transform.
  * Frame inverse can also be stored for increased speed in downstream calculations.
@@ -132,6 +137,9 @@ public:
                                    const RobotModel &model,
                                    std::vector<double> &joint_pose) const = 0;
 
+  virtual
+  const void* getPointData() const = 0;
+
   /**@brief Get "all" joint poses that satisfy this point.
    * @param model Robot model  object used to calculate pose
    * @param joint_poses vector of solutions (if function successful). Note: # of solutions may be subject to discretization used.
@@ -144,12 +152,6 @@ public:
    * @param model Robot model  object used to determine validity
    */
   virtual bool isValid(const RobotModel &model) const = 0;
-
-  /**@brief Set discretization. Note: derived classes interpret and use discretization differently.
-   * @param discretization Vector of discretization values.
-   * @return True if vector is valid length/values.
-   */
-  virtual bool setDiscretization(const std::vector<double> &discretization) = 0;
 
   /**@name Getters/Setters for ID
    * @{ */
@@ -170,9 +172,19 @@ public:
   }
   /** @} (end section) */
 
+  /**@name Sampling
+   * @{ */
+  virtual
+  bool setSampler(const TrajectoryPtSamplerPtr &sampler) = 0;
+
+  virtual
+  bool sample(size_t n) = 0;
+  /** @} (end section "Sampling" */
+
 protected:
   ID                            id_;                    /**<@brief ID associated with this pt. Generally refers back to a process path defined elsewhere. */
   TrajectoryPtTransitionPtr     transition_;            /**<@brief Velocities at, and interpolation method to reach this point **/
+  TrajectoryPtSamplerPtr        sampler_;               /**<@brief Sampler to be used on this point. **/
 
 };
 

--- a/descartes_core/src/cart_trajectory_pt.cpp
+++ b/descartes_core/src/cart_trajectory_pt.cpp
@@ -32,34 +32,20 @@ namespace descartes_core
 {
 
 CartTrajectoryPt::CartTrajectoryPt():
-    tool_base_(Eigen::Affine3d::Identity()),
-    tool_pt_(Eigen::Affine3d::Identity()),
-    wobj_base_(Eigen::Affine3d::Identity()),
-    wobj_pt_(Eigen::Affine3d::Identity())
+    point_data_()
 {}
 
-CartTrajectoryPt::CartTrajectoryPt(const Frame &wobj_base, const TolerancedFrame &wobj_pt, const Frame &tool,
-                 const TolerancedFrame &tool_pt):
-  tool_base_(tool),
-  tool_pt_(tool_pt),
-  wobj_base_(wobj_base),
-  wobj_pt_(wobj_pt)
+CartTrajectoryPt::CartTrajectoryPt(const Frame &wobj_base, const TolerancedFrame &wobj_pt,
+                                   const Frame &tool_base, const TolerancedFrame &tool_pt):
+  point_data_(wobj_base, wobj_pt, tool_base, tool_pt)
 {}
-
 
 CartTrajectoryPt::CartTrajectoryPt(const TolerancedFrame &wobj_pt):
-  tool_base_(Eigen::Affine3d::Identity()),
-  tool_pt_(Eigen::Affine3d::Identity()),
-  wobj_base_(Eigen::Affine3d::Identity()),
-  wobj_pt_(wobj_pt)
+  point_data_(Frame(Eigen::Affine3d::Identity()), wobj_pt, Frame(Eigen::Affine3d::Identity()), Frame(Eigen::Affine3d::Identity()))
 {}
 
-
 CartTrajectoryPt::CartTrajectoryPt(const Frame &wobj_pt):
-tool_base_(Eigen::Affine3d::Identity()),
-tool_pt_(Eigen::Affine3d::Identity()),
-wobj_base_(Eigen::Affine3d::Identity()),
-wobj_pt_(wobj_pt)
+    point_data_(Frame(Eigen::Affine3d::Identity()), wobj_pt, Frame(Eigen::Affine3d::Identity()), Frame(Eigen::Affine3d::Identity()))
 {}
 
 bool CartTrajectoryPt::getClosestCartPose(const std::vector<double> &seed_state,
@@ -72,7 +58,7 @@ bool CartTrajectoryPt::getNominalCartPose(const std::vector<double> &seed_state,
                                           const RobotModel &model, Eigen::Affine3d &pose) const
 {
   /* Simply return wobj_pt expressed in world */
-  pose = wobj_base_.frame * wobj_pt_.frame;
+  pose = point_data_.wobj_base.frame * point_data_.wobj_pt.frame;
   return true;  //TODO can this ever return false?
 }
 
@@ -92,8 +78,8 @@ bool CartTrajectoryPt::getNominalJointPose(const std::vector<double> &seed_state
                                            const RobotModel &model,
                                            std::vector<double> &joint_pose) const
 {
-  Eigen::Affine3d robot_pose = wobj_base_.frame * wobj_pt_.frame *
-      tool_pt_.frame_inv * tool_base_.frame_inv;
+  Eigen::Affine3d robot_pose = point_data_.wobj_base.frame * point_data_.wobj_pt.frame *
+      point_data_.tool_pt.frame_inv * point_data_.tool_base.frame_inv;
   return model.getIK(robot_pose, seed_state, joint_pose);
 }
 
@@ -101,8 +87,8 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model,
                                      std::vector<std::vector<double> > &joint_poses) const
 {
   bool rtn = false;
-  Eigen::Affine3d robot_pose = wobj_base_.frame * wobj_pt_.frame *
-      tool_pt_.frame_inv * tool_base_.frame_inv;
+  Eigen::Affine3d robot_pose = point_data_.wobj_base.frame * point_data_.wobj_pt.frame *
+      point_data_.tool_pt.frame_inv * point_data_.tool_base.frame_inv;
   if(model.getAllIK(robot_pose, joint_poses))
   {
     rtn = true;
@@ -115,15 +101,38 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model,
 
 bool CartTrajectoryPt::isValid(const RobotModel &model) const
 {
-  Eigen::Affine3d robot_pose = wobj_base_.frame * wobj_pt_.frame *
-      tool_pt_.frame_inv * tool_base_.frame_inv;
+  Eigen::Affine3d robot_pose = point_data_.wobj_base.frame * point_data_.wobj_pt.frame *
+      point_data_.tool_pt.frame_inv * point_data_.tool_base.frame_inv;
   return model.isValid(robot_pose);
 }
 
-
-bool CartTrajectoryPt::setDiscretization(const std::vector<double> &discretization)
+const void* CartTrajectoryPt::getPointData() const
 {
-  NOT_IMPLEMENTED_ERR(false);
+  return (const void*) &point_data_;
+}
+
+bool CartTrajectoryPt::setSampler(const TrajectoryPtSamplerPtr &sampler)
+{
+  sampler_ = sampler;
+  if (!sampler_->init(*this))
+  {
+    sampler_.reset();
+    return false;
+  }
+  return true;
+}
+
+bool CartTrajectoryPt::sample(size_t n)
+{
+  if (!sampler_)
+  {
+    logWarn("No sampler associated with point; Cannot sample.");
+    return false;
+  }
+
+//  const std::vector<std::vector<double> > solutions* = static_cast<const std::vector<std::vector<double> >* >(sampler_->sample());
+//  if (!sampler_->sample())
+  return true;
 }
 
 } /* namespace descartes_core */

--- a/descartes_core/src/samplers/joint_trajectory_pt_default_sampler.cpp
+++ b/descartes_core/src/samplers/joint_trajectory_pt_default_sampler.cpp
@@ -1,0 +1,154 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * trajectory_pt_sampler.h
+ *
+ *  Created on: Oct 29, 2014
+ *      Author: Dan Solomon
+ */
+
+#include <descartes_core/samplers/joint_trajectory_pt_default_sampler.h>
+#include <boost/uuid/uuid_io.hpp>
+
+
+namespace descartes_core
+{
+
+JointTrajectoryPtDefaultSampler::~JointTrajectoryPtDefaultSampler()
+{}
+
+JointTrajectoryPtDefaultSampler::SamplerState& JointTrajectoryPtDefaultSampler::SamplerState::operator ++()
+{
+  /* Check if sampling is done. Termination condition is that all joints provided all samples. */
+  done = true;
+  for (size_t joint_idx=0; joint_idx<samples.size(); ++joint_idx)
+  {
+    if (sample_idx[joint_idx] != samples[joint_idx].size()-1)
+    {
+      done = false;
+      break;
+    }
+  }
+  if (done)
+  {
+    return *this;
+  }
+
+  /* Walk along each joint.
+   *   If all samples have been taken of that joint, reset it to 0
+   *   If more samples remain, increment sample counter and stop looking
+   */
+  for (size_t joint_idx=0; joint_idx<samples.size(); ++joint_idx)
+  {
+    if (sample_idx[joint_idx] == samples[joint_idx].size()-1)
+    {
+      sample_idx[joint_idx] = 0;
+    }
+    else
+    {
+      ++sample_idx[joint_idx];
+      break;
+    }
+  }
+
+  return *this;
+}
+
+std::vector<double> JointTrajectoryPtDefaultSampler::SamplerState::current_sample()
+{
+  JointSample sample(samples.size());
+  for (size_t ii=0; ii<sample.size(); ++ii)
+  {
+    sample[ii] = samples[ii][sample_idx[ii]];
+  }
+  return sample;
+}
+
+bool JointTrajectoryPtDefaultSampler::init(const TrajectoryPt &pt)
+{
+  const JointTrajectoryPt::JointPointData* joints = static_cast<const JointTrajectoryPt::JointPointData*>(pt.getPointData());
+  //TODO this has to return false if cast doesn't work. Somehow incorporate dynamic cast?
+
+  sampler_state_.clear();
+  size_t n = joints->joint_position.size();
+  sampler_state_.samples.resize(n);
+  sampler_state_.sample_idx = std::vector<size_t>(n,0);
+
+  /* Populate samples
+   * Joint discretization set<=discretization_ such that upper/lower bounds of joint are included.
+   * Each joint is populated with [nom, nom+1, nom-1, nom+2, ...] until each bound is reached.
+   * In this manner, each sample steps incrementally farther away from the nominal.
+   */
+  for (size_t ii=0; ii<n; ++ii)
+  {
+    double nom = joints->joint_position.at(ii).nominal,
+           upper = joints->joint_position.at(ii).upperBound(),
+           lower = joints->joint_position.at(ii).lowerBound();
+    size_t upper_count = std::ceil((upper - nom) / discretization_[ii] - 2.0*std::numeric_limits<double>::epsilon()),
+           lower_count = std::ceil((nom - lower) / discretization_[ii] - 2.0*std::numeric_limits<double>::epsilon()); //TODO how else to get rid of rounding error?
+//    std::cout << "Upper/lower count " << upper_count << "/" << lower_count << std::endl;
+//    std::cout << nom << "/" << upper << "/" << lower << std::endl;
+    double upper_increment = upper_count != 0 ? (upper - nom)/(double)upper_count : std::numeric_limits<double>::max(),
+           lower_increment = lower_count != 0 ? (nom - lower)/(double)lower_count : std::numeric_limits<double>::max();
+
+    sampler_state_.samples[ii].push_back(nom);
+    for (size_t jj=0; jj<std::max(upper_count, lower_count); ++jj)
+    {
+      if (jj < upper_count)
+      {
+        sampler_state_.samples[ii].push_back(nom + double(jj) * upper_increment);
+      }
+      if (jj < lower_count)
+      {
+        sampler_state_.samples[ii].push_back(nom - double(jj) * lower_increment);
+      }
+    }
+  }
+
+  return true;
+}
+
+const void* JointTrajectoryPtDefaultSampler::sample(size_t n, const TrajectoryPt &pt)
+{
+  solution_storage_.clear();
+  bool get_all(n==0);
+  if (get_all)
+  {
+    n = 1;
+  }
+
+  size_t ii(0);
+  while (!sampler_state_.done && ii<n)
+  {
+    std::vector<double> solution = sampler_state_.current_sample();
+    ++sampler_state_;
+    if (solution.size() > 0)
+    {
+      solution_storage_.push_back(solution);
+    }
+
+    if (!get_all)
+    {
+      ++ii;
+    }
+  }
+
+  return (const void*) &solution_storage_;
+}
+
+} /* namespace descartes_core */

--- a/descartes_core/test/test_joint_trajectory_pt_default_sampler.cpp
+++ b/descartes_core/test/test_joint_trajectory_pt_default_sampler.cpp
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * test_joint_trajectory_pt_default_sampler.cpp
+ *
+ *  Created on: Nov 1, 2014
+ *      Author: dpsolomon
+ */
+
+#include "descartes_core/samplers/joint_trajectory_pt_default_sampler.h"
+#include "descartes_core/trajectory_pt.h"
+#include <gtest/gtest.h>
+
+using namespace descartes_core;
+typedef descartes_core::JointTrajectoryPtDefaultSampler::SampleData SampleData;
+
+
+size_t factorial(size_t n)
+{
+  size_t res(1);
+  for (size_t ii=2; ii<=n; ++ii)
+  {
+    res *= ii;
+  }
+  return res;
+}
+
+TEST(JointTrajPtDefaultSampler, externallyCalledSamplerSimple)
+{
+
+  descartes_core::JointTrajectoryPt pt(std::vector<double>(6, 0.));  /* Default JointPt has 0 tolerance */
+  descartes_core::JointTrajectoryPtDefaultSampler sampler;
+  sampler.setDiscretization(std::vector<double>(6,1.));
+  sampler.init(pt);
+
+  /* Test expected behavior */
+  const SampleData* solutions = static_cast<const SampleData* >(sampler.sample(0, pt));   /* Get all samples */
+  EXPECT_EQ(solutions->size(), 1);    /* Only 1 sample should be created (because pt has 0 tolerance) */
+
+  /* No additional samples should remain */
+  solutions = static_cast<const SampleData* >(sampler.sample(0, pt));
+  EXPECT_EQ(solutions->size(), 0);
+
+}
+
+TEST(JointTrajPtDefaultSampler, externallyCalledSamplerTwoPts)
+{
+  size_t n(2);  /* DOF */
+  descartes_core::JointTrajectoryPt pt1(std::vector<double>(n, 0.5)),   /* n joints set to position 0.5 (0 tolerance)*/
+                                    pt2;
+  std::vector<TolerancedJointValue> pt2_joints(n);
+  for (size_t ii=0; ii<n; ++ii)
+  {
+    TolerancedJointValue tjv;
+    tjv.nominal = 0.1;
+    tjv.tolerance.lower = tjv.tolerance.upper = 0.2;
+    pt2_joints[ii] = tjv;
+  }
+  pt2.setJoints(pt2_joints);                                            /* n joints set to position 0.1, (+/- 0.2 tolerance) */
+
+  JointTrajectoryPtDefaultSampler sampler1;
+  sampler1.setDiscretization(std::vector<double>(n, 0.1));
+  sampler1.init(pt1);
+
+  JointTrajectoryPtDefaultSampler sampler2 = sampler1;
+  sampler2.init(pt2);
+
+  const SampleData* sols;
+  sols = static_cast<const SampleData* >(sampler1.sample(0, pt1));
+  EXPECT_EQ(sols->size(), 1);
+  sols = static_cast<const SampleData* >(sampler2.sample(0, pt2));
+  EXPECT_EQ(sols->size(), 25);
+
+  sols = static_cast<const SampleData* >(sampler2.sample(5, pt2));       /* No more samples left */
+  EXPECT_EQ(sols->size(), 0);
+
+  sampler2.init(pt2);                   /* Reinitialize sampler for pt2 */
+  sols = static_cast<const SampleData* >(sampler2.sample(5, pt2));       /* Get first 5 samples */
+  EXPECT_EQ(sols->size(), 5);
+
+  EXPECT_EQ(1, factorial(1));
+  EXPECT_EQ(2, factorial(2));
+  EXPECT_EQ(6, factorial(3));
+  EXPECT_EQ(24, factorial(4));
+  EXPECT_EQ(120, factorial(5));
+  EXPECT_EQ(720, factorial(6));
+}


### PR DESCRIPTION
DO NOT MERGE THIS PR!

This PR is for discussion only, it is not ready to be merged. Please let me know your thoghts on implementing a sampler. Some notes I already realize:
- I don't have a good way of passing data of different `TrajectoryPts` to the sampler
- I would like associate a sampler with each `TrajectoryPt` and implement `TrajectoryPt::sample()` which calls the pt's associated sampler, but I have to resolve some issues, including how two classes can easily depend on each other (sampler would depend on pt, pt would depend on sampler. Maybe its not a big deal if they remain in one `descartes_core` library?)
- The `SamplerState` currently holds alot of data as of the `init()` call. I would like to have the `operator++` actually calculate the next sample instead of just retrieving it from an array of precalculated samples.

I have included a unit test to show how the sampler may be used.
