### PR TITLE
Refactored RobotModel test code to be parameterized gtest

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS
     include
+    test
   LIBRARIES
     descartes_core
   CATKIN_DEPENDS
@@ -43,6 +44,7 @@ add_library(descartes_core
             src/joint_trajectory_pt.cpp
             src/trajectory.cpp
             src/planning_graph.cpp
+            src/robot_model.cpp
 )
 ##Disabling planning graph due to issues with
 ##Trajectory point ID

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -40,6 +40,17 @@ DESCARTES_CLASS_FORWARD(RobotModel);
 class RobotModel
 {
 public:
+
+
+  /**
+    * Compares two vectors for equality (within +/- tolerance).  abs(lhs - rhs) > tol
+    * @param lhs
+    * @param rhs
+    * @param tol +/- tolerance for floating point equality
+    */
+  static bool equal(const std::vector<double> &lhs, const std::vector<double> &rhs,
+                                        const double tol);
+
   RobotModel()
   {
   }

--- a/descartes_core/src/robot_model.cpp
+++ b/descartes_core/src/robot_model.cpp
@@ -1,0 +1,49 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "descartes_core/robot_model.h"
+
+namespace descartes_core
+{
+
+bool RobotModel::equal(const std::vector<double> &lhs, const std::vector<double> &rhs,
+                               const double tol)
+{
+  bool rtn = false;
+  if( lhs.size() == rhs.size() )
+  {
+    rtn = true;
+    for(size_t ii = 0; ii < lhs.size(); ++ii)
+    {
+      if(std::fabs(lhs[ii]-rhs[ii]) > tol)
+      {
+        rtn = false;
+        break;
+      }
+    }
+
+  }
+  else
+  {
+    rtn = false;
+  }
+  return rtn;
+}
+
+} //descartes_core
+

--- a/descartes_core/test/descartes_core_test/robot_model_test.hpp
+++ b/descartes_core/test/descartes_core_test/robot_model_test.hpp
@@ -1,0 +1,121 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ROBOT_MODEL_TEST_HPP_
+#define ROBOT_MODEL_TEST_HPP_
+
+#include "descartes_core/pretty_print.hpp"
+#include "descartes_core/robot_model.h"
+#include "ros/console.h"
+#include <gtest/gtest.h>
+
+/**
+  @brief: This file contains inerface test for the Descartes RobotModel.  These
+  tests can be executed on arbitrary types that inplment the RobotModel interface.
+  For more info see:
+  <a href="https://code.google.com/p/googletest/wiki/AdvancedGuide#Type-Parameterized_Tests">
+    GTest Advanced Guide - Type-Parameterized Tests
+  </a>
+  */
+
+namespace descartes_core_test
+{
+
+template <class T>
+descartes_core::RobotModelPtr CreateRobotModel();
+
+template <class T>
+class RobotModelTest : public ::testing::Test
+{
+public:
+  RobotModelTest() : model_(CreateRobotModel<T>())
+  {
+    ROS_INFO("Instantiated RobotModelTest fixture(base) (parameterized)");
+  }
+
+  virtual void SetUp()
+  {
+    ROS_INFO("Setting up RobotModelTest fixture(base) (parameterized)");
+    ASSERT_TRUE(this->model_);
+  }
+
+  virtual void TearDown()
+  {
+    ROS_INFO("Tearing down RobotModelTest fixture(base) (parameterized)");
+  }
+
+  virtual ~RobotModelTest()
+  {
+    ROS_INFO("Desctructing RobotModelTest fixture(base) (parameterized)");
+  }
+
+  descartes_core::RobotModelPtr model_;
+};
+
+using namespace descartes_core;
+
+TYPED_TEST_CASE_P(RobotModelTest);
+
+const double TF_EQ_TOL = 0.001;
+const double JOINT_EQ_TOL = 0.001;
+
+
+TYPED_TEST_P(RobotModelTest, construction) {
+  ROS_INFO_STREAM("Robot model test construction");
+}
+
+
+TYPED_TEST_P(RobotModelTest, getIK) {
+  ROS_INFO_STREAM("Testing getIK");
+  std::vector<double> fk_joint(6, 0.0);
+  std::vector<double> ik_joint;
+  Eigen::Affine3d ik_pose, fk_pose;
+  EXPECT_TRUE(this->model_->getFK(fk_joint, ik_pose));
+  EXPECT_TRUE(this->model_->getIK(ik_pose, fk_joint, ik_joint));
+  //This doesn't always work, but it should.  The IKFast solution doesn't
+  //return the "closets" solution.  Numeric IK does appear to do this.
+  EXPECT_TRUE(RobotModel::equal(fk_joint, ik_joint, JOINT_EQ_TOL));
+  EXPECT_TRUE(this->model_->getFK(ik_joint, fk_pose));
+  EXPECT_TRUE(ik_pose.matrix().isApprox(fk_pose.matrix(), TF_EQ_TOL));
+  ROS_INFO_STREAM("getIK Test completed");
+}
+
+TYPED_TEST_P(RobotModelTest, getAllIK) {
+  ROS_INFO_STREAM("Testing getAllIK");
+  std::vector<double> fk_joint(6, 0.5);
+  std::vector<std::vector<double> > joint_poses;
+  Eigen::Affine3d ik_pose, fk_pose;
+
+  EXPECT_TRUE(this->model_->getFK(fk_joint, ik_pose));
+  EXPECT_TRUE(this->model_->getAllIK(ik_pose, joint_poses));
+  ROS_INFO_STREAM("Get all IK returned " << joint_poses.size() << " solutions");
+  std::vector<std::vector<double> >::iterator it;
+  for (it = joint_poses.begin(); it != joint_poses.end(); ++it)
+  {
+    ROS_INFO_STREAM("GetIK joint solution: " << *it);
+    EXPECT_TRUE(this->model_->getFK(*it, fk_pose));
+    EXPECT_TRUE(ik_pose.matrix().isApprox(fk_pose.matrix(), TF_EQ_TOL));
+  }
+}
+
+
+REGISTER_TYPED_TEST_CASE_P(RobotModelTest, construction, getIK, getAllIK);
+
+} //descartes_core_test
+
+#endif // ROBOT_MODEL_TEST_HPP_

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -35,15 +35,6 @@ class MoveitStateAdapter : public descartes_core::RobotModel
 public:
 
   /**
-    * Compares two vectors for equality (within +/- tolerance).  abs(lhs - rhs) > tol
-    * @param lhs
-    * @param rhs
-    * @param tol +/- tolerance for floating point equality
-    */
-  static bool equal(const std::vector<double> &lhs, const std::vector<double> &rhs,
-                                        const double tol);
-
-  /**
    * Constructor for Moveit state adapters (implements Descartes robot model interface)
    * @param robot_state robot state object utilized for kinematic/dynamic state checking
    * @param group_name planning group name

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -29,30 +29,6 @@
 namespace descartes_moveit
 {
 
-bool MoveitStateAdapter::equal(const std::vector<double> &lhs, const std::vector<double> &rhs,
-                               const double tol)
-{
-  bool rtn = false;
-  if( lhs.size() == rhs.size() )
-  {
-    rtn = true;
-    for(size_t ii = 0; ii < lhs.size(); ++ii)
-    {
-      if(std::fabs(lhs[ii]-rhs[ii]) > tol)
-      {
-        rtn = false;
-        break;
-      }
-    }
-
-  }
-  else
-  {
-    rtn = false;
-  }
-  return rtn;
-}
-
 MoveitStateAdapter::MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
                                      const std::string & tool_frame, const std::string & wobj_frame,
                                        const size_t sample_iterations) :

--- a/descartes_moveit/test/launch/moveit_state_adapter.launch
+++ b/descartes_moveit/test/launch/moveit_state_adapter.launch
@@ -1,0 +1,30 @@
+<launch>
+  <!-- Unit test launch file -->
+
+  <!-- Load up parameter server, based on standard planning_context.launch moveit file-->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+
+  <!-- URDF file (including path) -->
+  <arg name="urdf_file" default="$(find descartes_moveit)/test/resources/kuka_kr210/kr210l150.urdf"/>
+
+  <!-- Launch test node -->
+  <arg name="run_test_node" default="true"/>
+
+  <!-- Load universal robot description format (URDF) -->
+  <param name="$(arg robot_description)" textfile="$(arg urdf_file)"/>
+
+  <!-- The semantic description that corresponds to the URDF -->
+  <param name="$(arg robot_description)_semantic" textfile="$(find descartes_moveit)/test/resources/kuka_kr210/kuka_kr210.srdf" />
+  
+  <!-- Load updated joint limits (override information from URDF) -->
+  <group ns="$(arg robot_description)_planning">
+    <rosparam command="load" file="$(find descartes_moveit)/test/resources/kuka_kr210/joint_limits.yaml"/>
+  </group>
+
+  <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
+  <group ns="$(arg robot_description)_kinematics">
+    <rosparam command="load" file="$(find descartes_moveit)/test/resources/kuka_kr210/kinematics.yaml"/>
+  </group>
+  
+</launch>

--- a/descartes_moveit/test/launch/utest.launch
+++ b/descartes_moveit/test/launch/utest.launch
@@ -1,28 +1,19 @@
 <launch>
   <!-- Unit test launch file -->
 
-  <!-- Load up parameter server, based on standard planning_context.launch moveit file-->
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Launch test node -->
   <arg name="run_test_node" default="true"/>
 
-  <!-- Load universal robot description format (URDF) -->
-  <param name="$(arg robot_description)" textfile="$(find descartes_moveit)/test/resources/kuka_kr210/kr210l150.urdf"/>
 
-  <!-- The semantic description that corresponds to the URDF -->
-  <param name="$(arg robot_description)_semantic" textfile="$(find descartes_moveit)/test/resources/kuka_kr210/kuka_kr210.srdf" />
-  
-  <!-- Load updated joint limits (override information from URDF) -->
-  <group ns="$(arg robot_description)_planning">
-    <rosparam command="load" file="$(find descartes_moveit)/test/resources/kuka_kr210/joint_limits.yaml"/>
-  </group>
 
-  <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
-  <group ns="$(arg robot_description)_kinematics">
-    <rosparam command="load" file="$(find descartes_moveit)/test/resources/kuka_kr210/kinematics.yaml"/>
-  </group>
+  <include file="$(find descartes_moveit)/test/launch/moveit_state_adapter.launch">
+    <arg name="robot_description" value="$(arg robot_description)"/>
+    <arg name="urdf_file" value="$(find descartes_moveit)/test/resources/kuka_kr210/kr210l150.urdf"/>
+    <arg name="run_test_node" value="$(arg run_test_node)"/>
+  </include>
 
   <!-- Test Node -->
   <test test-name="utest" pkg="descartes_moveit" type="descartes_moveit_utest" if="$(arg run_test_node)"/>


### PR DESCRIPTION
Pulled `RobotModel` interface test into `descartes_core`.  Tests can not be pulled into any implementation of `RobotModel` (`descartes_moveit` and others).
