### PR TITLE
Initial implementation (take 2) of TrajectoryPtSamplers

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(descartes_core
             src/trajectory.cpp
             src/planning_graph.cpp
             src/robot_model.cpp
+            src/samplers/joint_trajectory_pt_default_sampler.cpp
 )
 ##Disabling planning graph due to issues with
 ##Trajectory point ID
@@ -64,7 +65,8 @@ if(CATKIN_ENABLE_TESTING)
       test/cart_trajectory_pt.cpp
       test/joint_trajectory_pt.cpp
       test/cartesian_robot.cpp
-      test/cartesian_robot_test.cpp)
+      test/cartesian_robot_test.cpp
+      test/test_jt_trajectory_pt_default_sampler)
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
 endif()

--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(descartes_core
             src/planning_graph.cpp
             src/robot_model.cpp
             src/samplers/joint_trajectory_pt_default_sampler.cpp
+            src/samplers/cart_trajectory_pt_default_yaw_sampler.cpp
 )
 ##Disabling planning graph due to issues with
 ##Trajectory point ID
@@ -66,7 +67,9 @@ if(CATKIN_ENABLE_TESTING)
       test/joint_trajectory_pt.cpp
       test/cartesian_robot.cpp
       test/cartesian_robot_test.cpp
-      test/test_jt_trajectory_pt_default_sampler)
+      test/test_jt_trajectory_pt_default_sampler
+      test/test_cart_trajectory_pt_default_yaw_sampler.cpp
+      )
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
 endif()

--- a/descartes_core/include/descartes_core/cart_trajectory_pt.h
+++ b/descartes_core/include/descartes_core/cart_trajectory_pt.h
@@ -25,9 +25,11 @@
 #ifndef CART_TRAJECTORY_PT_H_
 #define CART_TRAJECTORY_PT_H_
 
+#include <eigen_stl_containers/eigen_stl_vector_container.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
+#include <ros/console.h>
 #include "descartes_core/trajectory_pt.h"
-#include "ros/console.h"
+#include "descartes_core/samplers/cart_pt_sampler_base.h"
 
 typedef boost::shared_ptr<kinematic_constraints::PositionConstraint> PositionConstraintPtr;
 typedef boost::shared_ptr<kinematic_constraints::OrientationConstraint> OrientationConstraintPtr;
@@ -168,6 +170,28 @@ struct TolerancedFrame: public Frame
   OrientationTolerance          orientation_tolerance;
   PositionConstraintPtr         position_constraint;
   OrientationConstraintPtr      orientation_constraint;
+
+  Eigen::Vector3d upperPositionBound() const
+  {
+    return frame.translation() + Eigen::Vector3d(position_tolerance.x_upper, position_tolerance.y_upper, position_tolerance.z_upper);
+  }
+
+  Eigen::Vector3d lowerPositionBound() const
+  {
+    return frame.translation() - Eigen::Vector3d(position_tolerance.x_lower, position_tolerance.y_lower, position_tolerance.z_lower);
+  }
+
+  Eigen::Vector3d upperRPYBound() const
+  {
+    Eigen::Vector3d rpy = frame.rotation().eulerAngles(2,1,0);
+    return Eigen::Vector3d(rpy(2), rpy(1), rpy(0)) + Eigen::Vector3d(orientation_tolerance.x_upper, orientation_tolerance.y_upper, orientation_tolerance.z_upper);  //TODO check that this is correct
+  }
+
+  Eigen::Vector3d lowerRPYBound() const
+  {
+    Eigen::Vector3d rpy = frame.rotation().eulerAngles(2,1,0);
+    return Eigen::Vector3d(rpy(2), rpy(1), rpy(0)) - Eigen::Vector3d(orientation_tolerance.x_lower, orientation_tolerance.y_lower, orientation_tolerance.z_lower);  //TODO check that this is correct
+  }
 };
 
 
@@ -288,6 +312,36 @@ public:
     wobj_pt_ = pt;
   }
 
+  /** @name Sampling
+   * @{
+   */
+  /**@brief Assign a Cartesian pt sampler for tool frame of CartTrajectoryPt (similar to @e setWobjSampler).
+   *
+   * If successful, @e tool_sampler_ will be assigned to @e sampler.
+   *
+   * @param[in] sampler Shared ptr to a CartPtSampler.
+   * @return True if sampler is initialized with point data.
+   */
+  virtual
+  bool setToolSampler(const CartPtSamplerBasePtr &sampler);
+  virtual
+  bool setWobjSampler(const CartPtSamplerBasePtr &sampler);
+
+
+  /**@brief Get samples. This implementation is called by sampleTool() and sampleGoal().
+   *
+   * @param n Number of times to perform sampling. Actual number of returned samples may be different. A value of 0 means to get all available remaining samples.
+   * @param sampler_ Sampler to use for sampling.
+   * @return Set of Cartesian frame samples.
+   */
+  virtual
+  EigenSTL::vector_Affine3d sample(size_t n, CartPtSamplerBasePtr &sampler_);
+  virtual
+  EigenSTL::vector_Affine3d sampleTool(size_t n);
+  virtual
+  EigenSTL::vector_Affine3d sampleWobj(size_t n);
+
+  /** @} (end section) */
 
 protected:
   Frame                         tool_base_;     /**<@brief Fixed transform from wrist/tool_plate to tool base. */
@@ -297,6 +351,9 @@ protected:
 
   double                        pos_increment_;    /**<@brief Sampling discretization in cartesian directions. */
   double                        orient_increment_; /**<@brief Sampling discretization in angular orientation. */
+
+  CartPtSamplerBasePtr          tool_sampler_,  /**<@brief Cartesian sampler for tool frame. */
+                                wobj_sampler_;  /**<@brief Cartesian sampler for wobj frame. */
 
 };
 

--- a/descartes_core/include/descartes_core/joint_trajectory_pt.h
+++ b/descartes_core/include/descartes_core/joint_trajectory_pt.h
@@ -27,6 +27,8 @@
 
 #include <vector>
 #include "descartes_core/trajectory_pt.h"
+#include "descartes_core/samplers/joint_pt_sampler_base.h"
+
 
 namespace descartes_core
 {
@@ -179,6 +181,29 @@ inline
     wobj_ = wobj;
   }
   /**@} (end Setters section) */
+
+  /** @name Sampling
+   * @{
+   */
+  /**@brief Assign a joint pt sampler to JointTrajectoryPt.
+   *
+   * If successful, @e sampler_ will be assigned to @e sampler.
+   *
+   * @param[in] sampler Shared ptr to a JointPtSampler.
+   * @return True if sampler is initialized with point data.
+   */
+  virtual
+  bool setSampler(const JointPtSamplerBasePtr &sampler);
+
+  /**@brief Get samples
+   *
+   * @param n Desired number of samples. Actual number of returned samples may be lower. A value of 0 means to get all available remaining samples.
+   * @return Set of joint position samples.
+   */
+  virtual
+  std::vector<std::vector<double> > sample(size_t n);
+  /** @} (end section) */
+
 protected:
   std::vector<TolerancedJointValue> joint_position_;  /**<@brief Fixed joint position with tolerance */
   std::vector<double>               discretization_;  /**<@brief How finely to discretize each joint */
@@ -189,6 +214,8 @@ protected:
   Frame                         tool_;                  /**<@brief Transform from robot wrist to active tool pt. */
   Frame                         wobj_;                  /**<@brief Transform from world to active workobject pt. */
   /** @} (end section) */
+
+  JointPtSamplerBasePtr         sampler_;               /**<@brief Joint Pt Sampler */
 
 };
 

--- a/descartes_core/include/descartes_core/samplers/cart_pt_sampler_base.h
+++ b/descartes_core/include/descartes_core/samplers/cart_pt_sampler_base.h
@@ -1,0 +1,89 @@
+/*
+* Software License Agreement (Apache License)
+*
+* Copyright (c) 2014, Dan Solomon
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * cart_pt_sampler_base.h
+ *
+ *  Created on: Dec 2, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef CART_PT_SAMPLER_BASE_H_
+#define CART_PT_SAMPLER_BASE_H_
+
+#include <Eigen/Geometry>
+#include <vector>
+#include "descartes_core/utils.h"
+
+
+namespace descartes_core
+{
+
+DESCARTES_CLASS_FORWARD(CartPtSamplerBase);
+
+/**@brief CartPtSamplerBase class handles creating Cartesian frame samples.
+ *
+ * A sampler must be initialized with nominal position, upper and lower bounds, and desired discretization.
+ * Then, @e sample() can be called repeatedly until all the samples are returned.
+ *
+ */
+class CartPtSamplerBase
+{
+public:
+CartPtSamplerBase() {};
+virtual ~CartPtSamplerBase() {};
+
+/**@name Discretization
+ *
+ * Sample increment describes how to increment the value of each sample.
+ * For a Cartesian sampler, 6 sampling increment values are needed, 3 for position and 3 for rotation.
+ * It is left up to the implementation as to how the rotation increments are used.
+ * @{
+ */
+virtual
+std::vector<double> getSampleIncrement() const = 0;
+virtual
+void setSampleIncrement(const std::vector<double> &values) = 0;
+/** @} (end section) */
+
+/**@brief Initialize sampler data
+* @param[in] nominal
+* @param[in] upper_bound
+* @param[in] lower_bound
+* @param[in] discretization
+* @return True if init successful.
+*/
+virtual
+bool initPositionData(const Eigen::Affine3d &nominal,
+                      const Eigen::Vector3d &upper_position_bound, const Eigen::Vector3d &lower_position_bound,
+                      const Eigen::Vector3d &upper_rpy_bound, const Eigen::Vector3d &lower_rpy_bound) = 0;
+
+/**@brief Return Cartesian frame sample.
+*
+* Subsequent calls to this function return additional solutions (if they remain. If sampler is complete, will return false).
+*
+* @param[out] result Resultant joint state sample.
+* @return True if any new samples were successfully generated.
+*/
+virtual
+bool sample(Eigen::Affine3d &result) = 0;
+
+}; /* class CartPtSamplerBase */
+}  /* namespace descartes_core */
+
+
+#endif /* CART_PT_SAMPLER_BASE_H_ */

--- a/descartes_core/include/descartes_core/samplers/cart_trajectory_pt_default_yaw_sampler.h
+++ b/descartes_core/include/descartes_core/samplers/cart_trajectory_pt_default_yaw_sampler.h
@@ -1,0 +1,64 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * cart_trajectory_pt_default_yaw_sampler.h
+ *
+ *  Created on: Dec 9, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef CART_TRAJECTORY_PT_DEFAULT_YAW_SAMPLER_H_
+#define CART_TRAJECTORY_PT_DEFAULT_YAW_SAMPLER_H_
+
+#include <descartes_core/samplers/cart_pt_sampler_base.h>
+
+
+namespace descartes_core
+{
+
+class CartTrajectoryPtDefaultYawSampler : public CartPtSamplerBase
+{
+public:
+  virtual ~CartTrajectoryPtDefaultYawSampler() {};
+
+  virtual
+  std::vector<double> getSampleIncrement() const;
+  virtual
+  void setSampleIncrement(const std::vector<double> &values);
+
+  virtual
+  bool initPositionData(const Eigen::Affine3d &nominal,
+                        const Eigen::Vector3d &upper_position_bound = Eigen::Vector3d::Zero(), const Eigen::Vector3d &lower_position_bound = Eigen::Vector3d::Zero(),
+                        const Eigen::Vector3d &upper_rpy_bound = Eigen::Vector3d::Zero(), const Eigen::Vector3d &lower_rpy_bound = Eigen::Vector3d::Zero());
+
+  virtual
+  bool sample(Eigen::Affine3d &result);
+
+protected:
+
+  /* Private Members */
+  std::vector<double> increment_;
+  Eigen::Affine3d nominal_;
+  std::vector<double> yaw_samples_;
+  size_t sample_idx_;
+
+};
+
+} /* namespace descartes_core */
+
+#endif /* CART_TRAJECTORY_PT_DEFAULT_YAW_SAMPLER_H_ */

--- a/descartes_core/include/descartes_core/samplers/joint_pt_sampler_base.h
+++ b/descartes_core/include/descartes_core/samplers/joint_pt_sampler_base.h
@@ -1,0 +1,81 @@
+/*
+* Software License Agreement (Apache License)
+*
+* Copyright (c) 2014, Dan Solomon
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * joint_pt_sampler_base.h
+ *
+ *  Created on: Dec 2, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef JOINT_PT_SAMPLER_BASE_H_
+#define JOINT_PT_SAMPLER_BASE_H_
+
+#include <vector>
+#include "descartes_core/utils.h"
+
+
+namespace descartes_core
+{
+
+DESCARTES_CLASS_FORWARD(JointPtSamplerBase);
+
+/**@brief JointPtSamplerBase class handles creating joint position samples.
+ *
+ * A sampler must A) have desired sample increment set and B) be initialized with nominal position, upper and lower bounds.
+ * Then, @e sample() can be called repeatedly until all samples are returned.
+ *
+ */
+class JointPtSamplerBase
+{
+public:
+JointPtSamplerBase() {};
+virtual ~JointPtSamplerBase() {};
+
+/**@name Discretization
+ * @{
+ */
+virtual
+std::vector<double> getSampleIncrement() const = 0;
+virtual
+void setSampleIncrement(const std::vector<double> &values) = 0;
+/** @} (end section) */
+
+/**@brief Initialize sampler data
+* @param[in] nominal
+* @param[in] upper_bound
+* @param[in] lower_bound
+* @return True if init successful.
+*/
+virtual
+bool initPositionData(const std::vector<double> &nominal, const std::vector<double> &upper_bound, const std::vector<double> &lower_bound) = 0;
+
+/**@brief Return joint pt sample.
+*
+* Subsequent calls to this function return additional solutions (if they remain. If sampler is complete, will return false).
+*
+* @param[out] result Resultant joint state sample.
+* @return True if new sample successfully generated.
+*/
+virtual
+bool sample(std::vector<double> &result) = 0;
+
+}; /* class JointPtSamplerBase */
+}  /* namespace descartes_core */
+
+
+#endif /* JOINT_PT_SAMPLER_BASE_H_ */

--- a/descartes_core/include/descartes_core/samplers/joint_trajectory_pt_default_sampler.h
+++ b/descartes_core/include/descartes_core/samplers/joint_trajectory_pt_default_sampler.h
@@ -1,0 +1,87 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * joint_trajectory_pt_default_sampler.h
+ *
+ *  Created on: Oct 29, 2014
+ *      Author: Dan Solomon
+ */
+
+#ifndef JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_
+#define JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_
+
+#include <descartes_core/samplers/joint_pt_sampler_base.h>
+
+
+namespace descartes_core
+{
+
+class JointTrajectoryPtDefaultSampler : public JointPtSamplerBase
+{
+public:
+  virtual ~JointTrajectoryPtDefaultSampler() {};
+
+  virtual
+  std::vector<double> getSampleIncrement() const;
+  virtual
+  void setSampleIncrement(const std::vector<double> &values);
+
+  virtual
+  bool initPositionData(const std::vector<double> &nominal, const std::vector<double> &upper_bound, const std::vector<double> &lower_bound);
+
+  virtual
+  bool sample(std::vector<double> &result);
+
+protected:
+
+  /**@brief SamplerState holds sample data and current state for a JointTrajectoryPt sampler.
+   *
+   * sampler.init**() initializes the SamplerState, and calls to sampler.sample() operate on it.
+   */
+  struct SamplerState
+  {
+    std::vector<std::vector<double> > samples;  /**<@brief Each joint is assigned a set of samples */
+    std::vector<size_t> sample_idx;             /**<@brief An index (into @e samples) of the current sample to be taken for each joint. */
+    bool done;                                  /**<@brief Flag set when all samples have been taken. */
+
+    /**@brief Retrieve current sample by getting each sample value by corresponding sample index.
+     * @return Joint position (empty vector if @e done is set.
+     */
+    std::vector<double> current_sample();
+
+    /**@brief Reset the SampleState. */
+    void clear();
+
+    /**@brief prefix incrementor
+     * Increments appropriate @e sample_idx. If @e done is set, does nothing.
+     */
+    SamplerState& operator++ ();
+
+    /**@brief postfix incrementor (see prefix incrementor) */
+    SamplerState operator++ (int);
+  };
+
+  /* Private Members */
+  SamplerState sampler_state_;          /**<@brief Sampler data and current state. */
+  std::vector<double> increment_;       /**<@brief Desired sample increment for each joint. */
+
+};
+
+} /* namespace descartes_core */
+
+#endif /* JOINT_TRAJECTORY_PT_DEFAULT_SAMPLER_H_ */

--- a/descartes_core/include/descartes_core/utils.h
+++ b/descartes_core/include/descartes_core/utils.h
@@ -20,7 +20,7 @@
 #define UTILS_H_
 
 #include <boost/shared_ptr.hpp>
-#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 /** \def DESCARTES_CLASS_FORWARD
     Macro that forward declares a class XXX, and also defines two shared ptrs with named XXXPtr and XXXConstPtr  */

--- a/descartes_core/src/joint_trajectory_pt.cpp
+++ b/descartes_core/src/joint_trajectory_pt.cpp
@@ -116,9 +116,25 @@ bool JointTrajectoryPt::isValid(const RobotModel &model) const
 return model.isValid(lower) && model.isValid(upper);
 }
 
+std::vector<std::vector<double> > JointTrajectoryPt::sample(size_t n)
+{
+  std::vector<double> sample;
+  std::vector<std::vector<double> > samples;
+  while (n==0 || samples.size()<n)
+  {
+    if (!sampler_->sample(sample) )
+    {
+      break;
+    }
+    //TODO check that sample is valid. All samples returned by current sampler should be valid, but that cannot be assured in the future
+    samples.push_back(sample);
+  }
+  return samples;
+}
+
 bool JointTrajectoryPt::setDiscretization(const std::vector<double> &discretization)
 {
-  if (discretization.size() != 1 || discretization.size() != joint_position_.size())
+  if (discretization.size() != 1 && discretization.size() != joint_position_.size())
   {
     logError("discretization must be size 1 or same size as joint count.");
     return false;
@@ -142,6 +158,29 @@ bool JointTrajectoryPt::setDiscretization(const std::vector<double> &discretizat
 
   discretization_ = discretization;
 
+  return true;
+}
+
+bool JointTrajectoryPt::setSampler(const JointPtSamplerBasePtr &sampler)
+{
+  size_t n = joint_position_.size();
+  std::vector<double> nominal(n), upper_bound(n), lower_bound(n);
+  for (size_t ii=0; ii<n; ++ii)
+  {
+    nominal[ii] = joint_position_[ii].nominal;
+    lower_bound[ii] = joint_position_[ii].lowerBound();
+    upper_bound[ii] = joint_position_[ii].upperBound();
+  }
+
+  //Note: It might be better if trajectory point doesn't know or care about discretization.
+  //TODO Assign discretization externally before calling setSampler().
+  sampler->setSampleIncrement(discretization_);
+  if (!sampler->initPositionData(nominal, upper_bound, lower_bound) )
+  {
+    return false;
+  }
+
+  sampler_ = sampler;
   return true;
 }
 

--- a/descartes_core/src/samplers/cart_trajectory_pt_default_yaw_sampler.cpp
+++ b/descartes_core/src/samplers/cart_trajectory_pt_default_yaw_sampler.cpp
@@ -1,0 +1,99 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * cart_trajectory_pt_default_yaw_sampler.h
+ *
+ *  Created on: Dec 9, 2014
+ *      Author: Dan Solomon
+ */
+
+#include "descartes_core/samplers/cart_trajectory_pt_default_yaw_sampler.h"
+#include "ros/console.h"
+
+
+namespace descartes_core
+{
+
+inline
+std::vector<double> CartTrajectoryPtDefaultYawSampler::getSampleIncrement() const
+{
+  return increment_;
+}
+
+inline
+void CartTrajectoryPtDefaultYawSampler::setSampleIncrement(const std::vector<double> &values)
+{
+  increment_ = values;
+}
+
+bool CartTrajectoryPtDefaultYawSampler::initPositionData(const Eigen::Affine3d &nominal,
+                                                         const Eigen::Vector3d &upper_position_bound, const Eigen::Vector3d &lower_position_bound,
+                                                         const Eigen::Vector3d &upper_rpy_bound, const Eigen::Vector3d &lower_rpy_bound)
+{
+  if (increment_.size() != 6)
+  {
+    ROS_ERROR("Could not initialize sampler because discretization (%lu) is not correct size (6).", increment_.size());
+    return false;
+  }
+
+  /* Populate samples
+   * Each yaw sample is populated with [nom, nom+1, nom-1, nom+2, ...] until each bound is reached.
+   * In this manner, each sample steps incrementally farther away from the nominal.
+   */
+  Eigen::Vector3d euler = nominal.rotation().eulerAngles(2, 1, 0);
+  double nominal_yaw = euler(0);
+  const double& upper_yaw_bound = upper_rpy_bound(2),
+                lower_yaw_bound = lower_rpy_bound(2),
+                yaw_discretization = increment_[5];
+  size_t upper_count = yaw_discretization != 0 ? std::ceil((upper_yaw_bound - nominal_yaw) / yaw_discretization - 2.0*std::numeric_limits<double>::epsilon()) : 0,
+         lower_count = yaw_discretization != 0 ? std::ceil((nominal_yaw - lower_yaw_bound) / yaw_discretization - 2.0*std::numeric_limits<double>::epsilon()) : 0; //TODO how else to get rid of rounding error?
+  double upper_increment = upper_count != 0 ? (upper_yaw_bound - nominal_yaw) / (double)upper_count : std::numeric_limits<double>::max(),
+         lower_increment = lower_count != 0 ? (nominal_yaw - lower_yaw_bound) / (double)lower_count : std::numeric_limits<double>::max();
+
+  yaw_samples_.push_back(nominal_yaw);
+  for (size_t ii=0; ii<std::max(upper_count, lower_count); ++ii)
+  {
+    if (ii < upper_count)
+    {
+      yaw_samples_.push_back(nominal_yaw + double(ii) * upper_increment);
+    }
+    if (ii < lower_count)
+    {
+      yaw_samples_.push_back(nominal_yaw - double(ii) * lower_increment);
+    }
+  }
+
+  sample_idx_ = 0;
+
+  return true;
+}
+
+bool CartTrajectoryPtDefaultYawSampler::sample(Eigen::Affine3d &result)
+{
+  if (sample_idx_ == yaw_samples_.size())
+  {
+    return false;
+  }
+
+  result = nominal_ * Eigen::AngleAxisd(yaw_samples_[sample_idx_], Eigen::Vector3d::UnitZ());  //TODO check that this is correct yaw axis. Better yet, set yaw axis somewhere.
+  ++sample_idx_;
+
+  return true;
+}
+
+} /* namespace descartes_core */

--- a/descartes_core/src/samplers/joint_trajectory_pt_default_sampler.cpp
+++ b/descartes_core/src/samplers/joint_trajectory_pt_default_sampler.cpp
@@ -1,0 +1,172 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * joint_trajectory_pt_default_sampler.h
+ *
+ *  Created on: Oct 29, 2014
+ *      Author: Dan Solomon
+ */
+
+#include "descartes_core/samplers/joint_trajectory_pt_default_sampler.h"
+#include "ros/console.h"
+
+
+namespace descartes_core
+{
+
+JointTrajectoryPtDefaultSampler::SamplerState& JointTrajectoryPtDefaultSampler::SamplerState::operator ++()
+{
+  /* Check if sampling is done. Termination condition is that all joints provided all samples. */
+  done = true;
+  for (size_t joint_idx=0; joint_idx<samples.size(); ++joint_idx)
+  {
+    if (sample_idx[joint_idx] != samples[joint_idx].size()-1)
+    {
+      done = false;
+      break;
+    }
+  }
+  if (done)
+  {
+    return *this;
+  }
+
+  /* Walk along each joint.
+   *   If all samples have been taken of that joint, reset it to 0
+   *   If more samples remain, increment sample counter and stop looking
+   */
+  for (size_t joint_idx=0; joint_idx<samples.size(); ++joint_idx)
+  {
+    if (sample_idx[joint_idx] == samples[joint_idx].size()-1)
+    {
+      sample_idx[joint_idx] = 0;
+    }
+    else
+    {
+      ++sample_idx[joint_idx];
+      break;
+    }
+  }
+
+  return *this;
+}
+
+JointTrajectoryPtDefaultSampler::SamplerState JointTrajectoryPtDefaultSampler::SamplerState::operator ++(int)
+{
+  SamplerState tmp(*this);
+  ++(*this);
+  return tmp;
+}
+
+void JointTrajectoryPtDefaultSampler::SamplerState::clear()
+{
+  samples.clear();
+  sample_idx.clear();
+  done = false;
+}
+
+std::vector<double> JointTrajectoryPtDefaultSampler::SamplerState::current_sample()
+{
+  std::vector<double> sample(samples.size());
+  for (size_t ii=0; ii<sample.size(); ++ii)
+  {
+    sample[ii] = samples[ii][sample_idx[ii]];
+  }
+  return sample;
+}
+
+
+inline
+std::vector<double> JointTrajectoryPtDefaultSampler::getSampleIncrement() const
+{
+  return increment_;
+}
+
+inline
+void JointTrajectoryPtDefaultSampler::setSampleIncrement(const std::vector<double> &values)
+{
+  increment_     = values;
+}
+
+bool JointTrajectoryPtDefaultSampler::initPositionData(const std::vector<double> &nominal, const std::vector<double> &upper_bound, const std::vector<double> &lower_bound)
+{
+  sampler_state_.clear();
+  size_t n = nominal.size();
+
+  if (increment_.size() != n)
+  {
+    ROS_ERROR("Could not initialize sampler because discretization is incorrect size.");
+    return false;
+  }
+  if (upper_bound.size() != n || lower_bound.size() != n)
+  {
+    ROS_ERROR("Bounds not same size as nominal.");
+    return false;
+  }
+
+  sampler_state_.samples.resize(n);
+  sampler_state_.sample_idx = std::vector<size_t>(n,0);
+
+  /* Populate samples
+   * Set joint discretization <= discretization_ such that upper/lower bounds of joint are included.
+   * Each joint is populated with [nom, nom+1, nom-1, nom+2, ...] until each bound is reached.
+   * In this manner, each sample steps incrementally farther away from the nominal.
+   */
+  for (size_t ii=0; ii<n; ++ii)
+  {
+    size_t upper_count = increment_[ii] != 0 ? std::ceil((upper_bound[ii] - nominal[ii]) / increment_[ii] - 2.0*std::numeric_limits<double>::epsilon()) : 0,
+           lower_count = increment_[ii] != 0 ? std::ceil((nominal[ii] - lower_bound[ii]) / increment_[ii] - 2.0*std::numeric_limits<double>::epsilon()) : 0; //TODO how else to get rid of rounding error?
+    double upper_increment = upper_count != 0 ? (upper_bound[ii] - nominal[ii]) / (double)upper_count : std::numeric_limits<double>::max(),
+           lower_increment = lower_count != 0 ? (nominal[ii] - lower_bound[ii]) / (double)lower_count : std::numeric_limits<double>::max();
+
+    sampler_state_.samples[ii].push_back(nominal[ii]);
+    for (size_t jj=0; jj<std::max(upper_count, lower_count); ++jj)
+    {
+      if (jj < upper_count)
+      {
+        sampler_state_.samples[ii].push_back(nominal[ii] + double(jj) * upper_increment);
+      }
+      if (jj < lower_count)
+      {
+        sampler_state_.samples[ii].push_back(nominal[ii] - double(jj) * lower_increment);
+      }
+    }
+  }
+
+  return true;
+}
+
+bool JointTrajectoryPtDefaultSampler::sample(std::vector<double> &result)
+{
+  if (sampler_state_.done)
+  {
+    return false;
+  }
+
+  std::vector<double> solution = sampler_state_.current_sample();
+  if (solution.size() == 0)
+  {
+    return false;
+  }
+
+  ++sampler_state_;
+  result = solution;
+  return true;
+}
+
+} /* namespace descartes_core */

--- a/descartes_core/test/test_cart_trajectory_pt_default_yaw_sampler.cpp
+++ b/descartes_core/test/test_cart_trajectory_pt_default_yaw_sampler.cpp
@@ -1,0 +1,142 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * test_cart_trajectory_pt_default_yaw_sampler.cpp
+ *
+ *  Created on: Dec 9, 2014
+ *      Author: Dan Solomon
+ */
+
+#include "descartes_core/samplers/cart_trajectory_pt_default_yaw_sampler.h"
+#include "descartes_core/cart_trajectory_pt.h"
+#include <gtest/gtest.h>
+
+using namespace descartes_core;
+
+
+size_t factorial(size_t n)
+{
+  size_t res(1);
+  for (size_t ii=2; ii<=n; ++ii)
+  {
+    res *= ii;
+  }
+  return res;
+}
+
+TEST(CartTrajPtDefaultYawSampler, externallyCalledSampler1)
+{
+  /* Nominal is Identity transform, no positional variance, +- 1 radian yaw variance. */
+  Eigen::Affine3d nominal(Eigen::Affine3d::Identity());
+  Eigen::Vector3d upper_position_bound(Eigen::Vector3d::Zero()), lower_position_bound(Eigen::Vector3d::Zero());
+  Eigen::Vector3d upper_rpy_bound(0., 0., 1.), lower_rpy_bound(0., 0., -1.);
+
+  /* Discretization is [x,y,z,r,p,y]
+   * Note: increment set to 0 position, 0 roll/pitch/yaw,
+   * so no sampling beyond nominal value will take place.
+   */
+  std::vector<double> increment(6,0);
+
+  /* Create sampler, initialize increment and position data */
+  descartes_core::CartTrajectoryPtDefaultYawSampler sampler;
+  sampler.setSampleIncrement(increment);
+  sampler.initPositionData(nominal, upper_position_bound, lower_position_bound, upper_rpy_bound, lower_rpy_bound);
+
+  /* Test expected behavior */
+  EigenSTL::vector_Affine3d solutions;
+  Eigen::Affine3d sample_solution;
+  while(sampler.sample(sample_solution))
+  {
+    solutions.push_back(sample_solution);
+  }
+  EXPECT_EQ(solutions.size(), 1);    /* Only 1 sample should be created (because pt has 0 sample increment) */
+
+  /* No additional samples should remain */
+  EXPECT_FALSE(sampler.sample(sample_solution));
+}
+
+TEST(CartTrajPtDefaultYawSampler, externallyCalledSampler2)
+{
+  /* Nominal is Identity transform, no positional variance, +- 1 radian yaw variance. */
+  Eigen::Affine3d nominal(Eigen::Affine3d::Identity());
+  Eigen::Vector3d upper_position_bound(Eigen::Vector3d::Zero()), lower_position_bound(Eigen::Vector3d::Zero());
+  Eigen::Vector3d upper_rpy_bound(0., 0., 1.), lower_rpy_bound(0., 0., -1.);
+
+  /* Discretization is [x,y,z,r,p,y]
+   * Note: increment set to 0 position, 0 roll/pitch, .1 yaw
+   */
+  std::vector<double> increment(6,0);
+  increment[5] = 0.1;
+
+  /* Create sampler, initialize increment and position data */
+  descartes_core::CartTrajectoryPtDefaultYawSampler sampler;
+  sampler.setSampleIncrement(increment);
+  sampler.initPositionData(nominal, upper_position_bound, lower_position_bound, upper_rpy_bound, lower_rpy_bound);
+
+  /* Test expected behavior */
+  EigenSTL::vector_Affine3d solutions;
+  Eigen::Affine3d sample_solution;
+  while(sampler.sample(sample_solution))
+  {
+    solutions.push_back(sample_solution);
+  }
+  EXPECT_EQ(solutions.size(), 21);
+
+  /* No additional samples should remain */
+  EXPECT_FALSE(sampler.sample(sample_solution));
+}
+
+//TEST(CartTrajPtDefaultYawSampler, internallyCalledSampler)
+//{
+//  size_t n(2);  /* DOF */
+//  descartes_core::JointTrajectoryPt pt;
+//  std::vector<TolerancedJointValue> joints(n);
+//  for (size_t ii=0; ii<n; ++ii)
+//  {
+//    TolerancedJointValue tjv;
+//    tjv.nominal = 0.1;
+//    tjv.tolerance.lower = tjv.tolerance.upper = 0.2;
+//    joints[ii] = tjv;
+//  }
+//  pt.setJoints(joints); /* n joints set to position 0.1, (+/- 0.2 tolerance) */
+//  std::vector<double> discretization(n, 0.1);
+//  pt.setDiscretization(discretization);    /* Note: discretization assigned to TrajectoryPt. Will be passed to sampler in setSampler() */
+//
+//  JointPtSamplerBasePtr sampler(new JointTrajectoryPtDefaultSampler);
+//  EXPECT_TRUE(pt.setSampler(sampler));                  /* Performs sampler initialization here */
+//
+//  std::vector<std::vector<double> > sols;
+//  sols = pt.sample(0);
+//  EXPECT_EQ(sols.size(), 25);
+//
+//  sols.clear();
+//  sols = pt.sample(5);       /* No more samples left */
+//  EXPECT_EQ(sols.size(), 0);
+//
+//  pt.setSampler(sampler);    /* Reinitialize sampler */
+//  sols.clear();
+//  sols = pt.sample(5);       /* Get first 5 samples */
+//  EXPECT_EQ(sols.size(), 5);
+//
+//  EXPECT_EQ(1, factorial(1));
+//  EXPECT_EQ(2, factorial(2));
+//  EXPECT_EQ(6, factorial(3));
+//  EXPECT_EQ(24, factorial(4));
+//  EXPECT_EQ(120, factorial(5));
+//  EXPECT_EQ(720, factorial(6));
+//}

--- a/descartes_core/test/test_jt_trajectory_pt_default_sampler.cpp
+++ b/descartes_core/test/test_jt_trajectory_pt_default_sampler.cpp
@@ -1,0 +1,106 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Dan Solomon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * test_jt_trajectory_pt_default_sampler.cpp
+ *
+ *  Created on: Dec 7, 2014
+ *      Author: Dan Solomon
+ */
+
+#include "descartes_core/samplers/joint_trajectory_pt_default_sampler.h"
+#include "descartes_core/joint_trajectory_pt.h"
+#include <gtest/gtest.h>
+
+using namespace descartes_core;
+
+
+TEST(JointTrajPtDefaultSampler, externallyCalledSampler1)
+{
+  std::vector<double> nominal(6, 0.), upper_bound(6, 0.), lower_bound(6, 0.);  /* Set nominal, upper, and lower all to 6x0 */
+  descartes_core::JointTrajectoryPtDefaultSampler sampler;
+  sampler.setSampleIncrement(std::vector<double>(6,1.));
+  sampler.initPositionData(nominal, upper_bound, lower_bound);
+
+  /* Test expected behavior */
+  std::vector<std::vector<double> > solutions;
+  std::vector<double> sample_solution;
+  while(sampler.sample(sample_solution))
+  {
+    solutions.push_back(sample_solution);
+  }
+  EXPECT_EQ(solutions.size(), 1);    /* Only 1 sample should be created (because pt has 0 tolerance) */
+
+  /* No additional samples should remain */
+  EXPECT_FALSE(sampler.sample(sample_solution));
+}
+
+TEST(JointTrajPtDefaultSampler, externallyCalledSampler2)
+{
+  std::vector<double> nominal(2, 0.), upper_bound(2, 2.), lower_bound(2, -2.);  /* Set nominal to 2x0., upper, and lower to 2x2. */
+  descartes_core::JointTrajectoryPtDefaultSampler sampler;
+  sampler.setSampleIncrement(std::vector<double>(2,1.));
+  sampler.initPositionData(nominal, upper_bound, lower_bound);
+
+  /* Test expected behavior */
+  std::vector<std::vector<double> > solutions;
+  std::vector<double> sample_solution;
+  while(sampler.sample(sample_solution))
+  {
+    solutions.push_back(sample_solution);
+  }
+  EXPECT_EQ(solutions.size(), 25);    /* Each of {n} joints has {(upper-lower)/increment+1} possibilities, ((range+1)/increment)^n => 5^2 */
+
+  /* No additional samples should remain */
+  EXPECT_FALSE(sampler.sample(sample_solution));
+}
+
+TEST(JointTrajPtDefaultSampler, internallyCalledSampler)
+{
+  size_t n(2);  /* DOF */
+  double tolerance = 0.2;
+  double increment = 0.1;
+  descartes_core::JointTrajectoryPt pt;
+  std::vector<TolerancedJointValue> joints(n);
+  for (size_t ii=0; ii<n; ++ii)
+  {
+    TolerancedJointValue tjv;
+    tjv.nominal = 0.1;
+    tjv.tolerance.lower = tjv.tolerance.upper = tolerance;
+    joints[ii] = tjv;
+  }
+  pt.setJoints(joints); /* n joints set to position 0.1, (+/- 0.2 tolerance) */
+  std::vector<double> discretization(n, increment);
+  pt.setDiscretization(discretization);    /* Note: discretization assigned to TrajectoryPt. Will be passed to sampler in setSampler() */
+
+  JointPtSamplerBasePtr sampler(new JointTrajectoryPtDefaultSampler);
+  EXPECT_TRUE(pt.setSampler(sampler));                  /* Performs sampler initialization here */
+
+  std::vector<std::vector<double> > sols;
+  sols = pt.sample(0);
+  EXPECT_EQ(sols.size(), std::pow((2*tolerance)/increment+1,n));
+
+  sols.clear();
+  sols = pt.sample(5);       /* No more samples left */
+  EXPECT_EQ(sols.size(), 0);
+
+  pt.setSampler(sampler);    /* Reinitialize sampler */
+  sols.clear();
+  sols = pt.sample(5);       /* Get first 5 samples */
+  EXPECT_EQ(sols.size(), 5);
+
+}


### PR DESCRIPTION
DO NOT MERGE THIS PR!

This PR is for discussion only, it is not ready to be merged. Please let me know your thoughts on implementing a sampler.   This PR beings to address #18.

Some differences from my last attempt (https://github.com/dpsolomon/descartes/tree/samplers):
- Each TrajectoryPt type has its own sampler, e.g. a JointSampler for a JointTrajectoryPt.
- Each sampler type has a pure base class.
