### PR TITLE
Issue #43 closest joint pose implementation

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(descartes_core)
 
 set(CMAKE_BUILD_TYPE Debug)
+add_definitions(-std=gnu++0x)
 
 find_package(catkin REQUIRED COMPONENTS
   console_bridge

--- a/descartes_core/include/descartes_core/cart_trajectory_pt.h
+++ b/descartes_core/include/descartes_core/cart_trajectory_pt.h
@@ -70,8 +70,8 @@ struct ToleranceBase
     #param tol Total tolerance zone (assumed symetric about nominal)
     */
   template<typename T>
-  static T createSymmetric(const double x, const double y, const double z,
-                                          const double tol)
+  static T createSymmetric(const double& x, const double& y, const double& z,
+                                          const double& tol)
   {
     return(createSymmetric<T>(x, y, z, tol, tol, tol));
   }
@@ -81,7 +81,7 @@ struct ToleranceBase
     @param x, y, z
     */
   template<typename T>
-  static T zeroTolerance(const double x, const double y, const double z)
+  static T zeroTolerance(const double& x, const double& y, const double& z)
   {
     return(createSymmetric<T>(x, y, z, 0.0, 0.0, 0.0));
   }
@@ -174,8 +174,8 @@ struct TolerancedFrame: public Frame
     orientation_tolerance = ToleranceBase::createSymmetric<OrientationTolerance>(rpy(2),rpy(1),rpy(0),0);
   };
 
-  TolerancedFrame(const Eigen::Affine3d &a, const PositionTolerance pos_tol,
-                  const OrientationTolerance orient_tol) :
+  TolerancedFrame(const Eigen::Affine3d &a, const PositionTolerance &pos_tol,
+                  const OrientationTolerance &orient_tol) :
     Frame(a), position_tolerance(pos_tol), orientation_tolerance(orient_tol){}
 
   PositionTolerance             position_tolerance;

--- a/descartes_core/include/descartes_core/pretty_print.hpp
+++ b/descartes_core/include/descartes_core/pretty_print.hpp
@@ -197,8 +197,8 @@ namespace pretty_print
             if (delimiters_type::values.prefix != NULL)
                 stream << delimiters_type::values.prefix;
 
-            if (begin(_container) != end(_container))
-            for (TIter it = begin(_container), it_end = end(_container); ; )
+            if (pretty_print::begin(_container) != pretty_print::end(_container))
+            for (TIter it = pretty_print::begin(_container), it_end = pretty_print::end(_container); ; )
             {
                 stream << *it;
 

--- a/descartes_core/src/cart_trajectory_pt.cpp
+++ b/descartes_core/src/cart_trajectory_pt.cpp
@@ -209,8 +209,10 @@ bool CartTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_state
 {
   Eigen::Affine3d nominal_pose,candidate_pose;
 
-  getNominalCartPose(seed_state,model,nominal_pose);
-  model.getFK(seed_state,candidate_pose);
+  if(!model.getFK(seed_state,candidate_pose))
+  {
+    return false;
+  }
 
   // getting pose values
   Eigen::Vector3d t = candidate_pose.translation();
@@ -221,12 +223,12 @@ bool CartTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_state
    std::make_tuple(t(0),wobj_pt_.position_tolerance.x_lower,wobj_pt_.position_tolerance.x_upper),
    std::make_tuple(t(1),wobj_pt_.position_tolerance.y_lower,wobj_pt_.position_tolerance.y_upper),
    std::make_tuple(t(2),wobj_pt_.position_tolerance.z_lower,wobj_pt_.position_tolerance.z_upper),
-   std::make_tuple(rpy(0),wobj_pt_.orientation_tolerance.x_lower,wobj_pt_.orientation_tolerance.x_upper),
+   std::make_tuple(rpy(2),wobj_pt_.orientation_tolerance.x_lower,wobj_pt_.orientation_tolerance.x_upper),
    std::make_tuple(rpy(1),wobj_pt_.orientation_tolerance.y_lower,wobj_pt_.orientation_tolerance.y_upper),
-   std::make_tuple(rpy(2),wobj_pt_.orientation_tolerance.z_lower,wobj_pt_.orientation_tolerance.z_upper)
+   std::make_tuple(rpy(0),wobj_pt_.orientation_tolerance.z_lower,wobj_pt_.orientation_tolerance.z_upper)
   };
 
-  std::vector<double> closest_pose_vals = {t(0),t(1),t(2),rpy(0),rpy(1),rpy(2)};
+  std::vector<double> closest_pose_vals = {t(0),t(1),t(2),rpy(2),rpy(1),rpy(0)};
   bool solve_ik = false;
   for(int i = 0; i < vals.size();i++)
   {

--- a/descartes_core/src/cart_trajectory_pt.cpp
+++ b/descartes_core/src/cart_trajectory_pt.cpp
@@ -22,12 +22,16 @@
  *      Author: Dan Solomon
  */
 
+#include <tuple>
+#include <map>
+#include <algorithm>
 #include <console_bridge/console.h>
 #include <ros/console.h>
 #include "descartes_core/cart_trajectory_pt.h"
 
 #define NOT_IMPLEMENTED_ERR(ret) logError("%s not implemented", __PRETTY_FUNCTION__); return ret;
 
+const double EQUALITY_TOLERANCE = 0.0001f;
 
 namespace descartes_core
 {
@@ -203,7 +207,71 @@ bool CartTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_state
                                            const RobotModel &model,
                                            std::vector<double> &joint_pose) const
 {
-  NOT_IMPLEMENTED_ERR(false);
+  Eigen::Affine3d nominal_pose,candidate_pose;
+
+  getNominalCartPose(seed_state,model,nominal_pose);
+  model.getFK(seed_state,candidate_pose);
+
+  // getting pose values
+  Eigen::Vector3d t = candidate_pose.translation();
+  Eigen::Vector3d rpy = candidate_pose.rotation().eulerAngles(2,1,0);
+
+  std::vector< std::tuple<double,double,double> > vals =
+  {
+   std::make_tuple(t(0),wobj_pt_.position_tolerance.x_lower,wobj_pt_.position_tolerance.x_upper),
+   std::make_tuple(t(1),wobj_pt_.position_tolerance.y_lower,wobj_pt_.position_tolerance.y_upper),
+   std::make_tuple(t(2),wobj_pt_.position_tolerance.z_lower,wobj_pt_.position_tolerance.z_upper),
+   std::make_tuple(rpy(0),wobj_pt_.orientation_tolerance.x_lower,wobj_pt_.orientation_tolerance.x_upper),
+   std::make_tuple(rpy(1),wobj_pt_.orientation_tolerance.y_lower,wobj_pt_.orientation_tolerance.y_upper),
+   std::make_tuple(rpy(2),wobj_pt_.orientation_tolerance.z_lower,wobj_pt_.orientation_tolerance.z_upper)
+  };
+
+  std::vector<double> closest_pose_vals = {t(0),t(1),t(2),rpy(0),rpy(1),rpy(2)};
+  bool solve_ik = false;
+  for(int i = 0; i < vals.size();i++)
+  {
+    auto &lower = std::get<1>(vals[i]);
+    auto &upper = std::get<2>(vals[i]);
+    auto &v = std::get<0>(vals[i]);
+
+    if( std::abs(upper -lower) > EQUALITY_TOLERANCE)
+    {
+      auto bounds = std::make_pair(lower,upper);
+      if(std::minmax({lower,v,upper}) != bounds)
+      {
+        solve_ik =  true;
+        closest_pose_vals[i] = v < lower ? lower : upper;
+      }
+    }
+    else
+    {
+      if(std::abs(v-lower) > EQUALITY_TOLERANCE)
+      {
+        solve_ik =  true;
+      }
+    }
+  }
+
+  if(solve_ik)
+  {
+    Eigen::Affine3d closest_pose = descartes_core::utils::toFrame(closest_pose_vals[0],
+                                                                 closest_pose_vals[1],
+                                                                 closest_pose_vals[2],
+                                                                 closest_pose_vals[3],
+                                                                 closest_pose_vals[4],
+                                                                 closest_pose_vals[5]);
+
+    if(!model.getIK(closest_pose,seed_state,joint_pose))
+    {
+      return false;
+    }
+  }
+  else
+  {
+    joint_pose.assign(seed_state.begin(),seed_state.end());
+  }
+
+  return true;
 }
 
 bool CartTrajectoryPt::getNominalJointPose(const std::vector<double> &seed_state,

--- a/descartes_core/test/cart_trajectory_pt.cpp
+++ b/descartes_core/test/cart_trajectory_pt.cpp
@@ -136,24 +136,33 @@ TEST(CartTrajPt, zeroTolerance)
 
 TEST(CartTrajPt, closestJointPose)
 {
-  const double POS_TOL = 2.0;
+  const double POS_TOL = 0.5f;
   const double POS_INC = 0.2;
-
   const double ORIENT_TOL = 1.0;
   const double ORIENT_INC = 0.2;
-
-  const double EPSILON = 0.001;
+  CartesianRobot robot(10,4);
 
   // declaring pose values
-  Eigen::Affine3d pose = descartes_core::utils::toFrame(4,5,2,0,0,M_PI/4);
-
+  const double x = 4.0f;
+  const double y = 5.0f;
+  const double z = 2.0f;
+  const double rx = 0.0f;
+  const double ry = 0.0f;
+  const double rz = M_PI/4;
+  std::vector<double> joint_pose                                                                                                                                                                                                                                                                                                                                                                                                                                                                = {x,y,z,rx,ry,rz};
+  Eigen::Affine3d frame_pose = descartes_core::utils::toFrame(x,y,z,rx,ry,rz);
 
   ROS_INFO_STREAM("Initializing tolerance cartesian point");
   CartTrajectoryPt cart_point(TolerancedFrame(
-                                utils::toFrame(0, 0, 0, 0, 0, 0),
-                                ToleranceBase::createSymmetric<PositionTolerance>(0.0, 0.0, 0.0, POS_TOL + EPSILON),
-                                ToleranceBase::createSymmetric<OrientationTolerance>(0.0, 0.0, 0.0, ORIENT_TOL + EPSILON)),
+                                utils::toFrame(x,y,z,rx,ry,rz),
+                                ToleranceBase::createSymmetric<PositionTolerance>(x,y,z, POS_TOL),
+                                ToleranceBase::createSymmetric<OrientationTolerance>(rx,ry,rz, ORIENT_TOL)),
                               POS_INC, ORIENT_INC);
 
-  EXPECT_EQ(true, true);
+  ROS_INFO_STREAM("Testing getClosestJointPose(...)");
+  std::vector<double> closest_joint_pose;
+  EXPECT_TRUE(cart_point.getClosestJointPose(joint_pose,robot,closest_joint_pose));
+
+  ROS_INFO_STREAM("Testing equality between seed joint pose and closest joint pose");
+  EXPECT_EQ(joint_pose,closest_joint_pose);
 }

--- a/descartes_core/test/cart_trajectory_pt.cpp
+++ b/descartes_core/test/cart_trajectory_pt.cpp
@@ -133,3 +133,27 @@ TEST(CartTrajPt, zeroTolerance)
   zero_tol_pos.getJointPoses(robot,joint_solutions);
   EXPECT_EQ(joint_solutions.size(), 1);
 }
+
+TEST(CartTrajPt, closestJointPose)
+{
+  const double POS_TOL = 2.0;
+  const double POS_INC = 0.2;
+
+  const double ORIENT_TOL = 1.0;
+  const double ORIENT_INC = 0.2;
+
+  const double EPSILON = 0.001;
+
+  // declaring pose values
+  Eigen::Affine3d pose = descartes_core::utils::toFrame(4,5,2,0,0,M_PI/4);
+
+
+  ROS_INFO_STREAM("Initializing tolerance cartesian point");
+  CartTrajectoryPt cart_point(TolerancedFrame(
+                                utils::toFrame(0, 0, 0, 0, 0, 0),
+                                ToleranceBase::createSymmetric<PositionTolerance>(0.0, 0.0, 0.0, POS_TOL + EPSILON),
+                                ToleranceBase::createSymmetric<OrientationTolerance>(0.0, 0.0, 0.0, ORIENT_TOL + EPSILON)),
+                              POS_INC, ORIENT_INC);
+
+  EXPECT_EQ(true, true);
+}


### PR DESCRIPTION
This PR addresses issue #43 as follows:
- Implemented CartesianPt::getClosestJointPose(...) with the following approach:
  1. Computes FK using the seed_pose passed to the method.
  2. Computes the x,y ,z, rx, ry,rz from the pose obtained from FK.  The orientation values are computed with the Eigen::eulerAngles(...) method
  3. Each pose value is then checked to verify that it is within the points tolerance.  If it isn't then that value is set to one of the bounds for the points pose and ik is solved for the modified pose values
- Created Unit test to validate the method described above.

Note:  Since the Eigen::getEuler method may return different rpy combination for slightly different poses this approach may occasionally yield orientation values that  are outside the cartesian point tolerances.  Thus, the closest joint pose returned in these cases could be really far from the seed pose when in practice there could be a much closer one.

@shaun-edwards , @dpsolomon, any suggestions will be very welcomed. 
