### PR TITLE
Sparse trajectory planner

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -63,7 +63,8 @@ if(CATKIN_ENABLE_TESTING)
       test/cart_trajectory_pt.cpp
       test/joint_trajectory_pt.cpp
       test/cartesian_robot.cpp
-      test/cartesian_robot_test.cpp)
+      test/cartesian_robot_test.cpp
+      test/sparse_planner.cpp)
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
 endif()

--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(descartes_core)
 
 set(CMAKE_BUILD_TYPE Debug)
-
+add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
   console_bridge
   moveit_core
@@ -44,11 +44,10 @@ add_library(descartes_core
             src/joint_trajectory_pt.cpp
             src/trajectory.cpp
             src/planning_graph.cpp
+            src/sparse_planner.cpp
             src/robot_model.cpp
 )
-##Disabling planning graph due to issues with
-##Trajectory point ID
-##  src/planning_graph.cpp
+
 target_link_libraries(descartes_core
                       ${catkin_LIBRARIES}
 )

--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -64,7 +64,6 @@ if(CATKIN_ENABLE_TESTING)
       test/joint_trajectory_pt.cpp
       test/cartesian_robot.cpp
       test/cartesian_robot_test.cpp)
-      #test/sparse_planner.cpp)
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
 

--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -63,8 +63,15 @@ if(CATKIN_ENABLE_TESTING)
       test/cart_trajectory_pt.cpp
       test/joint_trajectory_pt.cpp
       test/cartesian_robot.cpp
-      test/cartesian_robot_test.cpp
-      test/sparse_planner.cpp)
+      test/cartesian_robot_test.cpp)
+      #test/sparse_planner.cpp)
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest descartes_core)
+
+  set(UTEST_SPARSE_PLANER_SRC_FILES test/utest.cpp
+      test/cartesian_robot.cpp
+      test/sparse_planner.cpp)
+  catkin_add_gtest(${PROJECT_NAME}_sparse_planner_utest ${UTEST_SPARSE_PLANER_SRC_FILES})
+  target_link_libraries(${PROJECT_NAME}_sparse_planner_utest descartes_core)
+
 endif()

--- a/descartes_core/include/descartes_core/pretty_print.hpp
+++ b/descartes_core/include/descartes_core/pretty_print.hpp
@@ -197,8 +197,8 @@ namespace pretty_print
             if (delimiters_type::values.prefix != NULL)
                 stream << delimiters_type::values.prefix;
 
-            if (begin(_container) != end(_container))
-            for (TIter it = begin(_container), it_end = end(_container); ; )
+            if (pretty_print::begin(_container) != pretty_print::end(_container))
+            for (TIter it = pretty_print::begin(_container), it_end = pretty_print::end(_container); ; )
             {
                 stream << *it;
 

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -89,6 +89,12 @@ public:
   virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const = 0;
 
   /**
+   * @brief Returns number of DOFs
+   * @return Int
+   */
+  virtual int getDOF() const = 0;
+
+  /**
    * @brief Performs all necessary checks to determine joint pose is valid
    * @param joint_pose Pose to check
    * @return True if valid

--- a/descartes_core/include/descartes_core/sparse_planner.h
+++ b/descartes_core/include/descartes_core/sparse_planner.h
@@ -1,0 +1,50 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * sparse_planner.h
+ *
+ *  Created on: Dec 17, 2014
+ *      Author: ros developer 
+ */
+
+#ifndef SPARSE_PLANNER_H_
+#define SPARSE_PLANNER_H_
+
+#include <descartes_core/planning_graph.h>
+
+namespace descartes_core
+{
+
+class SparsePlanner : public descartes_core::PlanningGraph
+{
+public:
+  SparsePlanner(RobotModelConstPtr &model);
+  virtual ~SparsePlanner();
+
+  bool setTrajectory(const std::vector<TrajectoryPt>& traj, double target_sampling = 0.1f);
+
+public:
+
+  double sampling_;
+  std::vector<TrajectoryPt> cart_points_;
+  std::map<TrajectoryPt::ID,JointTrajectoryPt> joint_points_map_;
+
+};
+
+} /* namespace descartes_core */
+#endif /* SPARSE_PLANNER_H_ */

--- a/descartes_core/include/descartes_core/sparse_planner.h
+++ b/descartes_core/include/descartes_core/sparse_planner.h
@@ -26,22 +26,45 @@
 #define SPARSE_PLANNER_H_
 
 #include <descartes_core/planning_graph.h>
+#include <tuple>
 
 namespace descartes_core
 {
 
 class SparsePlanner : public descartes_core::PlanningGraph
 {
+
 public:
-  SparsePlanner(RobotModelConstPtr &model);
+  typedef std::vector<std::tuple<int,TrajectoryPtPtr,JointTrajectoryPt> > SolutionArray;
+public:
+  SparsePlanner(RobotModelConstPtr &model,double sampling = 0.1f);
   virtual ~SparsePlanner();
 
-  bool setTrajectory(const std::vector<TrajectoryPt>& traj, double target_sampling = 0.1f);
+  void setSampling(double sampling);
+  bool setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj);
+  const std::map<TrajectoryPt::ID,JointTrajectoryPt>& getSolution();
 
-public:
+protected:
+
+  bool plan();
+  bool interpolateJointPose(const std::vector<double>& start,const std::vector<double>& end,
+                   double t,std::vector<double>& interp);
+  int interpolateSparseTrajectory(const SolutionArray& sparse_solution,int &sparse_index, int &point_pos);
+  void sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& sparse_trajectory_points,
+                        SolutionArray& solution_array);
+
+protected:
+
+  enum class InterpolationResult: int
+  {
+    ERROR = -1,
+    REPLAN,
+    SUCCESS
+  };
 
   double sampling_;
-  std::vector<TrajectoryPt> cart_points_;
+  std::vector<TrajectoryPtPtr> cart_points_;
+  SolutionArray sparse_solution_array_;
   std::map<TrajectoryPt::ID,JointTrajectoryPt> joint_points_map_;
 
 };

--- a/descartes_core/include/descartes_core/sparse_planner.h
+++ b/descartes_core/include/descartes_core/sparse_planner.h
@@ -42,9 +42,10 @@ public:
 
   void setSampling(double sampling);
   bool setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj);
-  bool addTrajectoryPointAfter(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
-  bool addTrajectoryPointBefore(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
-  bool modifyTrajectoryPoint(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
+  bool addTrajectoryPointAfter(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool addTrajectoryPointBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool modifyTrajectoryPoint(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool removeTrajectoryPoint(const TrajectoryPt::ID& ref_id);
   const std::map<TrajectoryPt::ID,JointTrajectoryPt>& getSolution();
   bool getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id,JointTrajectoryPt& j);
 
@@ -54,13 +55,16 @@ protected:
   bool interpolateJointPose(const std::vector<double>& start,const std::vector<double>& end,
                    double t,std::vector<double>& interp);
   int interpolateSparseTrajectory(const SolutionArray& sparse_solution,int &sparse_index, int &point_pos);
-  void sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& sparse_trajectory_points,
-                        SolutionArray& solution_array);
+  void sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& dense_trajectory_array,
+                        std::vector<TrajectoryPtPtr>& sparse_trajectory_array);
 
-  int getPointIndex(const TrajectoryPt::ID& ref_id);
+  int getDensePointIndex(const TrajectoryPt::ID& ref_id);
   int getSparsePointIndex(const TrajectoryPt::ID& ref_id);
+  int findNearestSparsePointIndex(const TrajectoryPt::ID& ref_id,bool skip_equal = true);
+  bool isInSparseTrajectory(const TrajectoryPt::ID& ref_id);
 
-  bool getOrderedSparseTrajectory(std::vector<TrajectoryPtPtr>& sparse_array);
+  bool getOrderedSparseCartesianArray(std::vector<TrajectoryPtPtr>& sparse_array);
+  bool getSparseSolutionArray(SolutionArray& sparse_solution_array);
 
 protected:
 

--- a/descartes_core/include/descartes_core/sparse_planner.h
+++ b/descartes_core/include/descartes_core/sparse_planner.h
@@ -42,7 +42,11 @@ public:
 
   void setSampling(double sampling);
   bool setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj);
+  bool addTrajectoryPointAfter(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
+  bool addTrajectoryPointBefore(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
+  bool modifyTrajectoryPoint(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp);
   const std::map<TrajectoryPt::ID,JointTrajectoryPt>& getSolution();
+  bool getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id,JointTrajectoryPt& j);
 
 protected:
 
@@ -52,6 +56,11 @@ protected:
   int interpolateSparseTrajectory(const SolutionArray& sparse_solution,int &sparse_index, int &point_pos);
   void sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& sparse_trajectory_points,
                         SolutionArray& solution_array);
+
+  int getPointIndex(const TrajectoryPt::ID& ref_id);
+  int getSparsePointIndex(const TrajectoryPt::ID& ref_id);
+
+  bool getOrderedSparseTrajectory(std::vector<TrajectoryPtPtr>& sparse_array);
 
 protected:
 

--- a/descartes_core/include/descartes_core/sparse_planner.h
+++ b/descartes_core/include/descartes_core/sparse_planner.h
@@ -41,11 +41,11 @@ public:
   virtual ~SparsePlanner();
 
   void setSampling(double sampling);
-  bool setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj);
-  bool addTrajectoryPointAfter(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
-  bool addTrajectoryPointBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
-  bool modifyTrajectoryPoint(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
-  bool removeTrajectoryPoint(const TrajectoryPt::ID& ref_id);
+  bool setPoints(const std::vector<TrajectoryPtPtr>& traj);
+  bool addPointAfter(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool addPointBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool modifyPoint(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp);
+  bool removePoint(const TrajectoryPt::ID& ref_id);
   const std::map<TrajectoryPt::ID,JointTrajectoryPt>& getSolution();
   bool getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id,JointTrajectoryPt& j);
 
@@ -63,7 +63,7 @@ protected:
   int findNearestSparsePointIndex(const TrajectoryPt::ID& ref_id,bool skip_equal = true);
   bool isInSparseTrajectory(const TrajectoryPt::ID& ref_id);
 
-  bool getOrderedSparseCartesianArray(std::vector<TrajectoryPtPtr>& sparse_array);
+  bool getOrderedSparseArray(std::vector<TrajectoryPtPtr>& sparse_array);
   bool getSparseSolutionArray(SolutionArray& sparse_solution_array);
 
 protected:

--- a/descartes_core/src/sparse_planner.cpp
+++ b/descartes_core/src/sparse_planner.cpp
@@ -23,10 +23,13 @@
  */
 
 #include <descartes_core/sparse_planner.h>
+#include <boost/uuid/uuid_io.hpp>
+#include <algorithm>
 
 namespace descartes_core
 {
 
+const int MAX_REPLANNING_ATTEMPTS = 100;
 
 SparsePlanner::SparsePlanner(RobotModelConstPtr &model,double sampling):
     PlanningGraph(model),
@@ -49,6 +52,8 @@ bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj
 {
   cart_points_.assign(traj.begin(),traj.end());
   sampleTrajectory(sampling_,cart_points_,sparse_solution_array_);
+  ROS_INFO_STREAM("Sampled trajectory contains "<<sparse_solution_array_.size()<<" points from "<<cart_points_.size()<<
+                  " points in the dense trajectory");
 
   // creating temporary sparse array
   std::vector<TrajectoryPtPtr> sparse_traj;
@@ -58,9 +63,251 @@ bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj
     sparse_traj.push_back(std::get<1>(t));
   }
 
-  if(insertGraph(&sparse_traj))
+  if(insertGraph(&sparse_traj) && plan())
   {
+    int planned_count = sparse_solution_array_.size();
+    int interp_count = cart_points_.size()  - sparse_solution_array_.size();
+    ROS_INFO("Sparse plan succeeded with %i planned point and %i interpolated points",planned_count,interp_count);
+  }
+  else
+  {
+    return false;
+  }
 
+  return true;
+}
+
+bool SparsePlanner::addTrajectoryPointAfter(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp)
+{
+  // finding position
+  auto predicate = [ref_id](TrajectoryPtPtr cp)
+    {
+      return ref_id== cp->getID();
+    };
+  auto pos = std::find_if(cart_points_.begin(),cart_points_.end(),predicate);
+  if(pos == cart_points_.end())
+  {
+    ROS_ERROR_STREAM("Point with ID "<<ref_id<<" was not found, aborting");
+    return false;
+  }
+
+  int index = std::distance(cart_points_.begin(),pos);
+  TrajectoryPt::ID prev_id, next_id;
+
+  if(index == cart_points_.size() - 1) // last element
+  {
+    prev_id = cart_points_.back()->getID();
+    next_id = boost::uuids::nil_uuid();
+
+    // inserting new point into sparse trajectory array
+    sparse_solution_array_.push_back(std::make_tuple(index,cp,JointTrajectoryPt()));
+  }
+  else
+  {
+    prev_id = cart_points_[index]->getID();
+    next_id = cart_points_[index+1]->getID();
+
+    // inserting new point into sparse trajectory array
+    auto sparse_pos = std::find_if(sparse_solution_array_.begin(),sparse_solution_array_.end(),
+                                   [index](std::tuple<int,TrajectoryPtPtr,JointTrajectoryPt>& t)
+                                         {
+                                           return index < std::get<0>(t);
+                                         });
+    if(sparse_pos != sparse_solution_array_.end())
+    {
+      sparse_solution_array_.insert(sparse_pos,std::make_tuple(index,cp,JointTrajectoryPt()));
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Point with ID "<<ref_id<<" could not be added to sparse trajectory array, aborting");
+      return false;
+    }
+  }
+
+
+  // replanning
+  if(addTrajectory(cp,prev_id,next_id) && plan())
+  {
+    int planned_count = sparse_solution_array_.size();
+    int interp_count = cart_points_.size()  - sparse_solution_array_.size();
+    ROS_INFO("Sparse plan succeeded with %i planned point and %i interpolated points",planned_count,interp_count);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool SparsePlanner::addTrajectoryPointBefore(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp)
+{
+  // finding position
+  auto predicate = [ref_id](TrajectoryPtPtr cp)
+    {
+      return ref_id== cp->getID();
+    };
+  auto pos = std::find_if(cart_points_.begin(),cart_points_.end(),predicate);
+  if(pos == cart_points_.end())
+  {
+    ROS_ERROR_STREAM("Reference ID "<<ref_id<<" was not found, aborting");
+    return false;
+  }
+
+  int index = std::distance(cart_points_.begin(),pos);
+  TrajectoryPt::ID prev_id, next_id;
+
+  if(index == 0) // first element
+  {
+    prev_id = boost::uuids::nil_uuid();
+    next_id = cart_points_.front()->getID();
+
+    // inserting new point into sparse trajectory array
+    sparse_solution_array_.insert(sparse_solution_array_.begin(),std::make_tuple(index,cp,JointTrajectoryPt()));
+  }
+  else
+  {
+    prev_id = cart_points_[index-1]->getID();
+    next_id = cart_points_[index]->getID();
+
+    // inserting new point into sparse trajectory array
+    auto sparse_pos = std::find_if(sparse_solution_array_.begin(),sparse_solution_array_.end(),
+                                   [index](std::tuple<int,TrajectoryPtPtr,JointTrajectoryPt>& t)
+                                         {
+                                           return index < std::get<0>(t);
+                                         });
+    if(sparse_pos != sparse_solution_array_.end())
+    {
+      sparse_solution_array_.insert(sparse_pos,std::make_tuple(index,cp,JointTrajectoryPt()));
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Point with ID "<<ref_id<<" could not be added to sparse trajectory array, aborting");
+      return false;
+    }
+  }
+
+  if(addTrajectory(cp,prev_id,next_id) && plan())
+  {
+    int planned_count = sparse_solution_array_.size();
+    int interp_count = cart_points_.size()  - sparse_solution_array_.size();
+    ROS_INFO("Sparse plan succeeded with %i planned point and %i interpolated points",planned_count,interp_count);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+int SparsePlanner::getPointIndex(const TrajectoryPt::ID& ref_id)
+{
+  int index = -1;
+  auto predicate = [ref_id](TrajectoryPtPtr cp)
+    {
+      return ref_id== cp->getID();
+    };
+
+  auto pos = std::find_if(cart_points_.begin(),cart_points_.end(),predicate);
+  if(pos == cart_points_.end())
+  {
+    index = std::distance(cart_points_.begin(),pos);
+  }
+
+  return index;
+}
+
+int SparsePlanner::getSparsePointIndex(const TrajectoryPt::ID& ref_id)
+{
+  int index = -1;
+  auto predicate = [ref_id](std::tuple<int,TrajectoryPtPtr,JointTrajectoryPt>& t)
+    {
+      return ref_id == std::get<1>(t)->getID();
+    };
+
+  auto pos = std::find_if(sparse_solution_array_.begin(),sparse_solution_array_.end(),predicate);
+  if(pos != sparse_solution_array_.end())
+  {
+    index = std::distance(sparse_solution_array_.begin(),pos);
+  }
+
+  return index;
+}
+
+bool SparsePlanner::getOrderedSparseTrajectory(std::vector<TrajectoryPtPtr>& sparse_array)
+{
+  const CartesianMap& cart_map = getCartesianMap();
+  TrajectoryPt::ID first_id = boost::uuids::nil_uuid();
+  auto predicate = [&first_id](const std::pair<TrajectoryPt::ID,CartesianPointInformation>& p)
+    {
+      const auto& info = p.second;
+      if(info.links_.id_previous == boost::uuids::nil_uuid())
+      {
+        first_id = p.first;
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+    };
+
+
+
+  if(cart_map.empty()
+      || (std::find_if(cart_map.begin(),cart_map.end(),predicate) == cart_map.end())
+      || first_id == boost::uuids::nil_uuid())
+  {
+    return false;
+  }
+
+  // copying point pointers in order
+  sparse_array.resize(cart_map.size());
+  TrajectoryPt::ID current_id = first_id;
+  for(int i = 0; i < sparse_array.size(); i++)
+  {
+    if(cart_map.count(current_id) == 0)
+    {
+      return false;
+    }
+
+    const CartesianPointInformation& info  = cart_map.at(current_id);
+    sparse_array[i] = info.source_trajectory_;
+    current_id = info.links_.id_next;
+  }
+
+  return true;
+}
+
+bool SparsePlanner::modifyTrajectoryPoint(TrajectoryPt::ID ref_id,TrajectoryPtPtr cp)
+{
+  int index = getPointIndex(ref_id);
+  if(index < 0)
+  {
+    return false;
+  }
+  // copying cartesian point
+  cp->setID(cart_points_[index]->getID());
+  cart_points_[index] = cp;
+
+  // copying point in sparse trajectory array if its there
+  int sparse_index = getSparsePointIndex(ref_id);
+  if(sparse_index < 0)
+  {
+    return false;
+  }
+
+  sparse_solution_array_[sparse_index] = std::make_tuple(index,cp,JointTrajectoryPt());
+
+  return true;
+}
+
+bool SparsePlanner::getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id, JointTrajectoryPt& j)
+{
+  if(joint_points_map_.count(cart_id) > 0)
+  {
+    j = joint_points_map_[cart_id];
   }
   else
   {
@@ -78,6 +325,7 @@ void SparsePlanner::sampleTrajectory(double sampling,const std::vector<Trajector
   {
     sparse_trajectory_points.push_back(std::make_tuple(i,dense_trajectory_points[i],JointTrajectoryPt()));
   }
+
 }
 
 bool SparsePlanner::interpolateJointPose(const std::vector<double>& start,const std::vector<double>& end,
@@ -106,7 +354,11 @@ bool SparsePlanner::plan()
   double cost;
 
   // solving coarse trajectory
-  if(getShortestPath(cost,sparse_joint_points) &&
+  bool replan = true;
+  bool succeeded = false;
+  int replanning_attempts = 0;
+  while(replan && (replanning_attempts++ < MAX_REPLANNING_ATTEMPTS)
+      && getShortestPath(cost,sparse_joint_points) &&
       (sparse_joint_points.size() == sparse_solution_array_.size()))
   {
     int i = 0;
@@ -117,15 +369,44 @@ bool SparsePlanner::plan()
       i++;
     }
     sparse_joint_points.clear();
+    int sparse_index, point_pos;
+    int result = interpolateSparseTrajectory(sparse_solution_array_,sparse_index,point_pos);
+    TrajectoryPt::ID prev_id, next_id;
+    TrajectoryPtPtr cart_point;
+    auto sparse_iter = sparse_solution_array_.begin();
+    switch(result)
+    {
+      case int(InterpolationResult::REPLAN):
+          replan = true;
+          cart_point = cart_points_[point_pos];
+          prev_id = cart_points_[point_pos - 1]->getID();
+          next_id = cart_points_[point_pos + 1]->getID();
+          std::advance(sparse_iter,sparse_index);
+          sparse_solution_array_.insert(sparse_iter,std::make_tuple(point_pos,cart_point,JointTrajectoryPt()));
+          if(addTrajectory(cart_point,prev_id,next_id))
+          {
+            ROS_INFO_STREAM("Added new point to sparse trajectory from dense trajectory at position "<<
+                            point_pos<<", re-planning entire trajectory");
+          }
+          else
+          {
+            ROS_INFO_STREAM("Adding point "<<point_pos <<"to sparse trajectory failed, aborting");
+            replan = false;
+            succeeded = false;
+          }
 
-    // TODO: call interpolateSparseTrajectory here
+          break;
+      case int(InterpolationResult::SUCCESS):
+          replan = false;
+          succeeded = true;
+          break;
+      case int(InterpolationResult::ERROR):
+          replan = false;
+          succeeded = false;
+          break;
+    }
+
   }
-  else
-  {
-    return false;
-  }
-
-
 
   return true;
 }
@@ -133,6 +414,7 @@ bool SparsePlanner::plan()
 int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solution,int &sparse_index, int &point_pos)
 {
   // populating full path
+  joint_points_map_.clear();
   std::vector<double> start_jpose, end_jpose, rough_interp, aprox_interp, seed_pose(robot_model_->getDOF(),0);
   for(int k = 1; k < sparse_solution.size(); k++)
   {
@@ -168,19 +450,6 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
       }
       else
       {
-/*        if(addTrajectory(cart_point,start_tpoint->getID(),end_tpoint->getID()) && getShortestPath(cost,sparse_joint_points))
-        {
-          auto pos_current = std::find(sparse_traj.begin(), sparse_traj.end(),end_tpoint);
-          auto pos_new = sparse_traj.insert(pos_current,cart_point);
-
-          // calculating index in joint list
-          auto joint_pos = sparse_joint_points.begin();
-          std::advance(joint_pos,std::distance(sparse_traj.begin(),pos_new));
-          joint_points_map_.insert(std::make_pair(cart_point->getID(),*joint_pos));
-
-          ROS_INFO_STREAM("Graph solved locally for point at position "<<i + j);
-        }*/
-
           sparse_index = k;
           point_pos = pos;
           return (int)InterpolationResult::REPLAN;

--- a/descartes_core/src/sparse_planner.cpp
+++ b/descartes_core/src/sparse_planner.cpp
@@ -59,8 +59,8 @@ bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj
 
   if(insertGraph(&sparse_trajectory_array) && plan())
   {
-    int planned_count = sparse_trajectory_array.size();
-    int interp_count = cart_points_.size()  - sparse_trajectory_array.size();
+    int planned_count = sparse_solution_array_.size();
+    int interp_count = cart_points_.size()  - sparse_solution_array_.size();
     ROS_INFO("Sparse plan succeeded with %i planned point and %i interpolated points",planned_count,interp_count);
   }
   else
@@ -409,11 +409,17 @@ bool SparsePlanner::getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id, J
 void SparsePlanner::sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& dense_trajectory_array,
                       std::vector<TrajectoryPtPtr>& sparse_trajectory_array)
 {
-  int skip = dense_trajectory_array.size()/sampling;
+  std::stringstream ss;
+  int skip = std::ceil(double(1.0f)/sampling);
+  ROS_INFO_STREAM("Sampling skip val: "<<skip<< " from sampling val: "<<sampling);
+  ss<<"[";
   for(int i = 0; i < dense_trajectory_array.size();i+=skip)
   {
     sparse_trajectory_array.push_back(dense_trajectory_array[i]);
+    ss<<i<<" ";
   }
+  ss<<"]";
+  ROS_INFO_STREAM("Sparse Indices:\n"<<ss.str());
 
   // add the last one
   if(sparse_trajectory_array.back()->getID() != dense_trajectory_array.back()->getID())
@@ -498,7 +504,7 @@ bool SparsePlanner::plan()
 
   }
 
-  return true;
+  return succeeded;
 }
 
 int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solution_array,int &sparse_index, int &point_pos)

--- a/descartes_core/src/sparse_planner.cpp
+++ b/descartes_core/src/sparse_planner.cpp
@@ -27,8 +27,10 @@
 namespace descartes_core
 {
 
-SparsePlanner::SparsePlanner(RobotModelConstPtr &model):
-    PlanningGraph(model)
+
+SparsePlanner::SparsePlanner(RobotModelConstPtr &model,double sampling):
+    PlanningGraph(model),
+    sampling_(sampling)
 {
 
 }
@@ -38,9 +40,159 @@ SparsePlanner::~SparsePlanner()
 
 }
 
-bool SparsePlanner::setTrajectory(const std::vector<TrajectoryPt>& traj, double target_sampling)
+void SparsePlanner::setSampling(double sampling)
 {
+  sampling_ = sampling;
+}
+
+bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj)
+{
+  cart_points_.assign(traj.begin(),traj.end());
+  sampleTrajectory(sampling_,cart_points_,sparse_solution_array_);
+
+  // creating temporary sparse array
+  std::vector<TrajectoryPtPtr> sparse_traj;
+  sparse_traj.reserve(sparse_solution_array_.size());
+  for(auto& t : sparse_solution_array_)
+  {
+    sparse_traj.push_back(std::get<1>(t));
+  }
+
+  if(insertGraph(&sparse_traj))
+  {
+
+  }
+  else
+  {
+    return false;
+  }
+
   return true;
+}
+
+void SparsePlanner::sampleTrajectory(double sampling,const std::vector<TrajectoryPtPtr>& dense_trajectory_points
+                                     ,SolutionArray& sparse_trajectory_points )
+{
+  int skip = dense_trajectory_points.size()/sampling;
+  for(int i = 0; i < dense_trajectory_points.size();i+=skip)
+  {
+    sparse_trajectory_points.push_back(std::make_tuple(i,dense_trajectory_points[i],JointTrajectoryPt()));
+  }
+}
+
+bool SparsePlanner::interpolateJointPose(const std::vector<double>& start,const std::vector<double>& end,
+    double t,std::vector<double>& interp)
+{
+  if(start.size() != end.size() && (t > 1 || t < 0))
+  {
+    return false;
+  }
+
+  interp.resize(start.size());
+  double val = 0.0f;
+  for(int i = 0; i < start.size(); i++)
+  {
+    val = end[i] - (end[i] - start[i]) * (1 - t);
+    interp[i] = val;
+  }
+
+  return true;
+}
+
+bool SparsePlanner::plan()
+{
+  typedef std::tuple< TrajectoryPt::ID,TrajectoryPt,JointTrajectoryPt > SolutionTuple ;
+  std::list<JointTrajectoryPt> sparse_joint_points;
+  double cost;
+
+  // solving coarse trajectory
+  if(getShortestPath(cost,sparse_joint_points) &&
+      (sparse_joint_points.size() == sparse_solution_array_.size()))
+  {
+    int i = 0;
+    for(auto& jp : sparse_joint_points)
+    {
+      auto& t = sparse_solution_array_[i];
+      std::get<2>(t) = jp;
+      i++;
+    }
+    sparse_joint_points.clear();
+
+    // TODO: call interpolateSparseTrajectory here
+  }
+  else
+  {
+    return false;
+  }
+
+
+
+  return true;
+}
+
+int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solution,int &sparse_index, int &point_pos)
+{
+  // populating full path
+  std::vector<double> start_jpose, end_jpose, rough_interp, aprox_interp, seed_pose(robot_model_->getDOF(),0);
+  for(int k = 1; k < sparse_solution.size(); k++)
+  {
+    auto start_index = std::get<0>(sparse_solution[k-1]);
+    auto end_index = std::get<0>(sparse_solution[k]);
+    TrajectoryPtPtr start_tpoint = std::get<1>(sparse_solution[k-1]);
+    TrajectoryPtPtr end_tpoint = std::get<1>(sparse_solution[k]);
+    const JointTrajectoryPt& start_jpoint = std::get<2>(sparse_solution[k-1]);
+    const JointTrajectoryPt& end_jpoint = std::get<2>(sparse_solution[k]);
+
+    start_jpoint.getNominalJointPose(seed_pose,*robot_model_,start_jpose);
+    end_jpoint.getNominalJointPose(seed_pose,*robot_model_,end_jpose);
+
+    // adding start joint point to solution
+    joint_points_map_.insert(std::make_pair(start_tpoint->getID(),start_jpoint));
+
+    // interpolating
+    int step = end_index - start_index;
+    for(int j = 1; (j < step) && ( (start_index + j) < cart_points_.size()); j++)
+    {
+      int pos = start_index+j;
+      double t = double(j)/double(step);
+      if(!interpolateJointPose(start_jpose,end_jpose,t,rough_interp))
+      {
+        ROS_ERROR_STREAM("Interpolation for point at position "<<pos<< "failed, aborting");
+        return (int)InterpolationResult::ERROR;
+      }
+
+      TrajectoryPtPtr cart_point = cart_points_[pos];
+      if(cart_point->getClosestJointPose(rough_interp,*robot_model_,aprox_interp))
+      {
+        joint_points_map_.insert(std::make_pair(cart_point->getID(),JointTrajectoryPt(aprox_interp)));
+      }
+      else
+      {
+/*        if(addTrajectory(cart_point,start_tpoint->getID(),end_tpoint->getID()) && getShortestPath(cost,sparse_joint_points))
+        {
+          auto pos_current = std::find(sparse_traj.begin(), sparse_traj.end(),end_tpoint);
+          auto pos_new = sparse_traj.insert(pos_current,cart_point);
+
+          // calculating index in joint list
+          auto joint_pos = sparse_joint_points.begin();
+          std::advance(joint_pos,std::distance(sparse_traj.begin(),pos_new));
+          joint_points_map_.insert(std::make_pair(cart_point->getID(),*joint_pos));
+
+          ROS_INFO_STREAM("Graph solved locally for point at position "<<i + j);
+        }*/
+
+          sparse_index = k;
+          point_pos = pos;
+          return (int)InterpolationResult::REPLAN;
+      }
+    }
+
+    // adding end joint point to solution
+    joint_points_map_.insert(std::make_pair(end_tpoint->getID(),start_jpoint));
+
+  }
+
+  return (int)InterpolationResult::SUCCESS;
 }
 
 } /* namespace descartes_core */

--- a/descartes_core/src/sparse_planner.cpp
+++ b/descartes_core/src/sparse_planner.cpp
@@ -49,7 +49,7 @@ void SparsePlanner::setSampling(double sampling)
   sampling_ = sampling;
 }
 
-bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj)
+bool SparsePlanner::setPoints(const std::vector<TrajectoryPtPtr>& traj)
 {
   cart_points_.assign(traj.begin(),traj.end());
   std::vector<TrajectoryPtPtr> sparse_trajectory_array;
@@ -70,7 +70,7 @@ bool SparsePlanner::setTrajectoryPoints(const std::vector<TrajectoryPtPtr>& traj
   return true;
 }
 
-bool SparsePlanner::addTrajectoryPointAfter(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
+bool SparsePlanner::addPointAfter(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
 {
   int sparse_index;
   int index;
@@ -113,7 +113,7 @@ bool SparsePlanner::addTrajectoryPointAfter(const TrajectoryPt::ID& ref_id,Traje
   return true;
 }
 
-bool SparsePlanner::addTrajectoryPointBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
+bool SparsePlanner::addPointBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
 {
   int sparse_index;
   int index;
@@ -154,7 +154,7 @@ bool SparsePlanner::addTrajectoryPointBefore(const TrajectoryPt::ID& ref_id,Traj
   return true;
 }
 
-bool SparsePlanner::removeTrajectoryPoint(const TrajectoryPt::ID& ref_id)
+bool SparsePlanner::removePoint(const TrajectoryPt::ID& ref_id)
 {
   int index = getDensePointIndex(ref_id);
   if(index == INVALID_INDEX)
@@ -191,7 +191,7 @@ bool SparsePlanner::removeTrajectoryPoint(const TrajectoryPt::ID& ref_id)
   return true;
 }
 
-bool SparsePlanner::modifyTrajectoryPoint(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
+bool SparsePlanner::modifyPoint(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
 {
   int sparse_index;
   TrajectoryPt::ID prev_id, next_id;
@@ -318,7 +318,7 @@ bool SparsePlanner::getSparseSolutionArray(SolutionArray& sparse_solution_array)
   double cost;
 
   if(!getShortestPath(cost,sparse_joint_points) ||
-      !getOrderedSparseCartesianArray(sparse_cart_points) ||
+      !getOrderedSparseArray(sparse_cart_points) ||
       (sparse_joint_points.size() != sparse_cart_points.size()))
   {
     ROS_ERROR_STREAM("Failed to find sparse joint solution");
@@ -347,7 +347,7 @@ bool SparsePlanner::getSparseSolutionArray(SolutionArray& sparse_solution_array)
   return true;
 }
 
-bool SparsePlanner::getOrderedSparseCartesianArray(std::vector<TrajectoryPtPtr>& sparse_array)
+bool SparsePlanner::getOrderedSparseArray(std::vector<TrajectoryPtPtr>& sparse_array)
 {
   const CartesianMap& cart_map = getCartesianMap();
   TrajectoryPt::ID first_id = boost::uuids::nil_uuid();

--- a/descartes_core/src/sparse_planner.cpp
+++ b/descartes_core/src/sparse_planner.cpp
@@ -1,0 +1,46 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2014, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * sparse_planner.cpp
+ *
+ *  Created on: Dec 17, 2014
+ *      Author: ros developer 
+ */
+
+#include <descartes_core/sparse_planner.h>
+
+namespace descartes_core
+{
+
+SparsePlanner::SparsePlanner(RobotModelConstPtr &model):
+    PlanningGraph(model)
+{
+
+}
+
+SparsePlanner::~SparsePlanner()
+{
+
+}
+
+bool SparsePlanner::setTrajectory(const std::vector<TrajectoryPt>& traj, double target_sampling)
+{
+  return true;
+}
+
+} /* namespace descartes_core */

--- a/descartes_core/test/cartesian_robot.cpp
+++ b/descartes_core/test/cartesian_robot.cpp
@@ -96,7 +96,10 @@ namespace descartes_core_test
     return rtn;
   }
 
-
+  int CartesianRobot::getDOF() const
+  {
+    return 6;
+  }
 
   bool CartesianRobot::isValid(const std::vector<double> &joint_pose) const
   {

--- a/descartes_core/test/descartes_core_test/cartesian_robot.h
+++ b/descartes_core/test/descartes_core_test/cartesian_robot.h
@@ -47,6 +47,8 @@ public:
 
   virtual bool isValid(const Eigen::Affine3d &pose) const;
 
+  virtual int getDOF() const;
+
   double pos_range_;
   double orient_range_;
 

--- a/descartes_core/test/sparse_planner.cpp
+++ b/descartes_core/test/sparse_planner.cpp
@@ -74,5 +74,5 @@ TEST(SparsePlanner, setTrajectoryPoints)
   descartes_core::SparsePlanner planner(robot);
 
   ROS_INFO_STREAM("Testing setTrajectoryPoints() with "<<NUM_DENSE_POINTS<<" dense points");
-  EXPECT_TRUE(planner.setTrajectoryPoints(TEST_TRAJECTORY));
+  EXPECT_TRUE(planner.setPoints(TEST_TRAJECTORY));
 }

--- a/descartes_core/test/sparse_planner.cpp
+++ b/descartes_core/test/sparse_planner.cpp
@@ -1,0 +1,75 @@
+#include <descartes_core/sparse_planner.h>
+#include "descartes_core/cart_trajectory_pt.h"
+#include "descartes_core/utils.h"
+#include "descartes_core_test/cartesian_robot.h"
+#include <gtest/gtest.h>
+#include <tuple>
+
+using namespace descartes_core;
+
+typedef std::vector<descartes_core::TrajectoryPtPtr> Trajectory;
+const int NUM_DENSE_POINTS = 200;
+Trajectory TEST_TRAJECTORY = createTestTrajectory();
+
+class TestPoint: public descartes_core::CartTrajectoryPt
+{
+public:
+  TestPoint(const std::vector<double>& joints)
+  {
+    vals_.resize(joints.size());
+    vals_.assign(vals_.begin(),joints.begin(),joints.end());
+  }
+
+  virtual ~TestPoint()
+  {
+
+  }
+
+  virtual bool getClosestJointPose(const std::vector<double> &seed_state,
+                                     const RobotModel &model,
+                                     std::vector<double> &joint_pose) const
+  {
+    joint_pose.clear();
+    joint_pose.assigns(vals.begin(),vals.end());
+    return true;
+  }
+
+protected:
+
+  std::vector<double> vals_;
+}
+
+Trajectory createTestTrajectory()
+{
+  Trajectory traj;
+  std::vector<std::tuple<double, double>>joint_bounds = {std::make_tuple(0,M_PI),
+                                                         std::make_tuple(-M_PI_2,M_PI_2),
+                                                         std::make_tuple(M_PI/8,M_PI/3)};
+  std::vector<double> deltas;
+  for(auto& e:joint_bounds)
+  {
+    double d = (std::get<1>(e) std::get<0>(e))/NUM_DENSE_POINTS;
+    deltas.push_back(d);
+  }
+
+  // creating trajectory points
+  std::vector<double> joint_vals(deltas.size(),0);
+  for(int i = 0 ; i < NUM_DENSE_POINTS; i++)
+  {
+    for(int j = 0; j < deltas.size(); j++)
+    {
+      joint_vals[j] = std::get<0>(joint_bounds[j]) + deltas[j]*i;
+    }
+    TrajectoryPtPtr tp(new TestPoint(joint_vals));
+    traj.push_back(tp);
+  }
+  return traj;
+}
+
+
+TEST(SparsePlanner, setTrajectoryPoints)
+{
+  descartes_core_test::CartesianRobot robot(0, 0);
+  descartes_core::SparsePlanner planner(robot);
+  EXPECT_TRUE(planner.setTrajectoryPoints(TEST_TRAJECTORY));
+}

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -61,6 +61,8 @@ public:
 
   virtual bool isValid(const Eigen::Affine3d &pose) const;
 
+  virtual int getDOF() const;
+
 protected:
 
   /**

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -228,5 +228,12 @@ bool MoveitStateAdapter::isValid(const Eigen::Affine3d &pose) const
   return getIK(pose, dummy);
 }
 
+int MoveitStateAdapter::getDOF() const
+{
+  const moveit::core::JointModelGroup* group;
+  group = robot_state_->getJointModelGroup(group_name_);
+  return group->getVariableCount();
+}
+
 } //descartes_moveit
 


### PR DESCRIPTION
This is PR addresses the issue #37 
- Added the SparsePlanner class for planning on a subset of points taken from a "denser" trajectory.
- It first generates a graph plan for the sparse set and then it interpolates through the remaining points in the 
  dense trajectory that were not included in the sparse set.
- It inherits from PlanningGraph and provides a similart interface as its base class
- Its interface includes methods for adding, modifying and removing points.
- Unit test programs loads a fake trajectory with 1000 points.

In order to run unit test run the following in a terminal:

```
catkin_make run_tests_descartes_core_gtest_descartes_core_sparse_planner_utest
```

@shaun-edwards  please review
