### PR TITLE
Issue #50 robot model collision

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -26,6 +26,8 @@
 namespace descartes_core
 {
 
+typedef std::map<std::string,std::string> RobotModelOptions;
+
 DESCARTES_CLASS_FORWARD(RobotModel);
 
 /**@brief RobotModel defines the interface to a kinematics/dynamics functions.  Implementations
@@ -101,6 +103,16 @@ public:
    */
   virtual bool initialize(const std::string robot_description, const std::string& group_name,
                           const std::string& world_frame,const std::string& tcp_frame) = 0;
+
+  /* @brief sets the configuration options.
+   * @param options map containing the key/value option pairs.
+   */
+  virtual bool setOptions(const RobotModelOptions& options) = 0;
+
+  /* @brief returns the current options used by this robot model
+   * @return RobotModelOptions map
+   */
+  virtual RobotModelOptions getOptions() = 0;
 
 protected:
 

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -26,8 +26,6 @@
 namespace descartes_core
 {
 
-typedef std::map<std::string,std::string> RobotModelOptions;
-
 DESCARTES_CLASS_FORWARD(RobotModel);
 
 /**@brief RobotModel defines the interface to a kinematics/dynamics functions.  Implementations
@@ -104,19 +102,31 @@ public:
   virtual bool initialize(const std::string robot_description, const std::string& group_name,
                           const std::string& world_frame,const std::string& tcp_frame) = 0;
 
-  /* @brief sets the configuration options.
-   * @param options map containing the key/value option pairs.
-   */
-  virtual bool setOptions(const RobotModelOptions& options) = 0;
 
-  /* @brief returns the current options used by this robot model
-   * @return RobotModelOptions map
+  /**
+   * @brief Enables collision checks
+   * @param check_collisions enables or disables collisions
    */
-  virtual RobotModelOptions getOptions() = 0;
+  virtual void setCheckCollisions(bool check_collisions)
+  {
+    check_collisions_ = check_collisions;
+  }
+
+  /**
+   * @brief Indicates if collision checks are enabled
+   * @return Bool
+   */
+  virtual bool getCheckCollisions()
+  {
+    return check_collisions_;
+  }
+
 
 protected:
 
-  RobotModel(){}
+  RobotModel(): check_collisions_(false){}
+
+  bool check_collisions_;
 
 };
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -61,6 +61,11 @@ public:
 
   virtual int getDOF() const;
 
+  /* @brief parses the RobotModelOptions map in order to set the options for the robot model
+   * @param options: a map containing the following entries:
+   *    - key: check_collision, type: bool
+   *    - key: sampled_discretization, type: double
+   */
   virtual bool setOptions(const descartes_core::RobotModelOptions& options);
 
   virtual descartes_core::RobotModelOptions getOptions();
@@ -109,6 +114,7 @@ protected:
    * @brief Joint solution sample iterations for returning "all" joints
    */
   size_t sample_iterations_;
+  bool check_collisions_;
 
   descartes_core::RobotModelOptions options_;
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -24,6 +24,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include "moveit/robot_model/robot_model.h"
 #include "moveit/kinematics_base/kinematics_base.h"
+#include <moveit/planning_scene/planning_scene.h>
 #include <string>
 
 namespace descartes_moveit
@@ -39,17 +40,6 @@ class MoveitStateAdapter : public descartes_core::RobotModel
 public:
 
   MoveitStateAdapter();
-
-  /**
-   * Constructor for Moveit state adapters (implements Descartes robot model interface)
-   * @param robot_state robot state object utilized for kinematic/dynamic state checking
-   * @param group_name planning group name
-   * @param tool_frame tool frame name
-   * @param world_frame work object frame name
-   */
-  MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
-                    const std::string & tool_frame, const std::string & world_frame,
-                     size_t sample_iterations = 10);
 
   virtual ~MoveitStateAdapter()
   {
@@ -71,6 +61,11 @@ public:
 
   virtual int getDOF() const;
 
+  virtual bool setOptions(const descartes_core::RobotModelOptions& options);
+
+  virtual descartes_core::RobotModelOptions getOptions();
+
+
 protected:
 
   /**
@@ -86,6 +81,7 @@ protected:
    * each function call
    */
   mutable moveit::core::RobotStatePtr robot_state_;
+  planning_scene::PlanningScenePtr planning_scene_;
   robot_model_loader::RobotModelLoaderPtr  robot_model_loader_;
   robot_model::RobotModelConstPtr robot_model_ptr_;
 
@@ -113,6 +109,8 @@ protected:
    * @brief Joint solution sample iterations for returning "all" joints
    */
   size_t sample_iterations_;
+
+  descartes_core::RobotModelOptions options_;
 
 };
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -41,6 +41,17 @@ public:
 
   MoveitStateAdapter();
 
+  /**
+   * Constructor for Moveit state adapters (implements Descartes robot model interface)
+   * @param robot_state robot state object utilized for kinematic/dynamic state checking
+   * @param group_name planning group name
+   * @param tool_frame tool frame name
+   * @param world_frame work object frame name
+   */
+  MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
+                    const std::string & tool_frame, const std::string & world_frame,
+                     size_t sample_iterations = 10);
+
   virtual ~MoveitStateAdapter()
   {
   }
@@ -61,16 +72,6 @@ public:
 
   virtual int getDOF() const;
 
-  /* @brief parses the RobotModelOptions map in order to set the options for the robot model
-   * @param options: a map containing the following entries:
-   *    - key: check_collision, type: bool
-   *    - key: sampled_discretization, type: double
-   */
-  virtual bool setOptions(const descartes_core::RobotModelOptions& options);
-
-  virtual descartes_core::RobotModelOptions getOptions();
-
-
 protected:
 
   /**
@@ -85,6 +86,14 @@ protected:
    * @brief Pointer to moveit robot state (mutable object state is reset with
    * each function call
    */
+
+  /**
+   * TODO: Checks for collisions at this joint pose. The setCollisionCheck(true) must have been
+   * called previously in order to enable collision checks, otherwise it will return false.
+   * @param joint_pose the joint values at which check for collisions will be made
+   */
+  bool isInCollision(const std::vector<double> &joint_pose) const;
+
   mutable moveit::core::RobotStatePtr robot_state_;
   planning_scene::PlanningScenePtr planning_scene_;
   robot_model_loader::RobotModelLoaderPtr  robot_model_loader_;
@@ -114,9 +123,6 @@ protected:
    * @brief Joint solution sample iterations for returning "all" joints
    */
   size_t sample_iterations_;
-  bool check_collisions_;
-
-  descartes_core::RobotModelOptions options_;
 
 };
 

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -27,54 +27,15 @@
 #define NOT_IMPLEMENTED_ERR logError("%s not implemented", __PRETTY_FUNCTION__)
 
 const static int SAMPLE_ITERATIONS = 10;
+const static std::string SAMPLE_ITERATIONS_OPTION = "sampled_iterations";
 
 namespace descartes_moveit
 {
 
-MoveitStateAdapter::MoveitStateAdapter()
+MoveitStateAdapter::MoveitStateAdapter():
+    sample_iterations_(SAMPLE_ITERATIONS)
 {
-
-}
-
-MoveitStateAdapter::MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
-                                     const std::string & tool_frame, const std::string & world_frame,
-                                       const size_t sample_iterations) :
-    robot_state_(new moveit::core::RobotState(robot_state)), group_name_(group_name),
-  tool_frame_(tool_frame), world_frame_(world_frame), sample_iterations_(sample_iterations),
-  world_to_root_(Eigen::Affine3d::Identity())
-{
-
-  moveit::core::RobotModelConstPtr robot_model_ = robot_state_->getRobotModel();
-  const moveit::core::JointModelGroup* joint_model_group_ptr = robot_state_->getJointModelGroup(group_name);
-  if (joint_model_group_ptr)
-  {
-    joint_model_group_ptr->printGroupInfo();
-
-    const std::vector<std::string>& link_names = joint_model_group_ptr->getLinkModelNames();
-    if (tool_frame_ != link_names.back())
-    {
-      logWarn("Tool frame '%s' does not match group tool frame '%s', functionality will be implemented in the future",
-               tool_frame_.c_str(), link_names.back().c_str());
-    }
-
-    if (world_frame_ != robot_state_->getRobotModel()->getModelFrame())
-    {
-      logWarn("World frame '%s' does not match model root frame '%s', all poses will be transformed to world frame '%s'",
-               world_frame_.c_str(), link_names.front().c_str(),world_frame_.c_str());
-
-      Eigen::Affine3d root_to_world = robot_state_->getFrameTransform(world_frame_);
-      world_to_root_ = descartes_core::Frame(root_to_world.inverse());
-    }
-
-  }
-  else
-  {
-    logError("Joint group: %s does not exist in robot model", group_name_.c_str());
-    std::stringstream msg;
-    msg << "Possible group names: " << robot_state_->getRobotModel()->getJointModelGroupNames();
-    logError(msg.str().c_str());
-  }
-  return;
+  options_ = {{SAMPLE_ITERATIONS_OPTION,std::to_string(sample_iterations_)}};
 }
 
 bool MoveitStateAdapter::initialize(const std::string robot_description, const std::string& group_name,
@@ -84,10 +45,10 @@ bool MoveitStateAdapter::initialize(const std::string robot_description, const s
   robot_model_loader_.reset(new robot_model_loader::RobotModelLoader(robot_description));
   robot_model_ptr_ = robot_model_loader_->getModel();
   robot_state_.reset(new moveit::core::RobotState(robot_model_ptr_));
+  planning_scene_.reset(new planning_scene::PlanningScene(robot_model_loader_->getModel()));
   group_name_ = group_name;
   tool_frame_ = tcp_frame;
   world_frame_ = world_frame;
-  sample_iterations_ = SAMPLE_ITERATIONS;
 
   const moveit::core::JointModelGroup* joint_model_group_ptr = robot_state_->getJointModelGroup(group_name);
   if (joint_model_group_ptr)
@@ -121,6 +82,36 @@ bool MoveitStateAdapter::initialize(const std::string robot_description, const s
   return true;
 }
 
+bool MoveitStateAdapter::setOptions(const descartes_core::RobotModelOptions& options)
+{
+  for(auto opt: options_)
+  {
+    if(options.count(opt.first) == 0)
+    {
+      ROS_ERROR_STREAM("Missing option "<<opt.first <<" found");
+      return false;
+    }
+  }
+
+  try
+  {
+    options_[SAMPLE_ITERATIONS_OPTION] = options.at(SAMPLE_ITERATIONS_OPTION);
+    sample_iterations_ = std::stoi(options.at(SAMPLE_ITERATIONS_OPTION));
+  }
+  catch(std::invalid_argument& exp)
+  {
+    ROS_ERROR_STREAM("Option string failed to be parsed: "<<exp.what());
+    return false;
+  }
+
+  return true;
+}
+
+descartes_core::RobotModelOptions MoveitStateAdapter::getOptions()
+{
+  return options_;
+}
+
 bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
                               std::vector<double> &joint_pose) const
 {
@@ -139,8 +130,11 @@ bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, std::vector<double> 
   if (robot_state_->setFromIK(robot_state_->getJointModelGroup(group_name_), tool_pose,
                               tool_frame_))
   {
-    robot_state_->copyJointGroupPositions(group_name_, joint_pose);
-    rtn = true;
+    if(!planning_scene_->isStateColliding(*robot_state_,group_name_))
+    {
+      robot_state_->copyJointGroupPositions(group_name_, joint_pose);
+      rtn = true;
+    }
   }
   else
   {

--- a/descartes_moveit/test/moveit_state_adapter_test.cpp
+++ b/descartes_moveit/test/moveit_state_adapter_test.cpp
@@ -42,24 +42,35 @@ robot_model_loader::RobotModelLoaderPtr robot_;
 template <>
 RobotModelPtr CreateRobotModel<descartes_moveit::MoveitStateAdapter>()
 {
-  //robot_model::RobotModelPtr moveit_model_;
-  //robot_state::RobotStatePtr state_;
-
-/*  ROS_INFO_STREAM("Loading robot model from parameter");
-  robot_ = robot_model_loader::RobotModelLoaderPtr(
-        new robot_model_loader::RobotModelLoader("robot_description"));
-  EXPECT_TRUE(robot_);
-
-  ROS_INFO_STREAM("Robot model loaded");
-  moveit_model_ = robot_->getModel();
-  state_ = robot_state::RobotStatePtr(new robot_state::RobotState(moveit_model_));*/
-
 
   ROS_INFO_STREAM("Construction descartes robot model");
   descartes_core::RobotModelPtr descartes_model_;
   descartes_model_ = descartes_core::RobotModelPtr(new descartes_moveit::MoveitStateAdapter());
   EXPECT_TRUE(descartes_model_->initialize("robot_description","manipulator","base_link","tool0"));
   ROS_INFO_STREAM("Descartes robot model constructed");
+
+  // getting default options
+  descartes_core::RobotModelOptions options = descartes_model_->getOptions();
+
+  ROS_INFO_STREAM("Default options");
+  for(auto opt : options)
+  {
+    ROS_INFO_STREAM("option name: "<<opt.first<<", value: "<<opt.second);
+  }
+
+  // setting options
+  options["sampled_iterations"] = std::to_string(20);
+  options["check_collisions"] = std::to_string(false);
+  EXPECT_TRUE(descartes_model_->setOptions(options));
+
+  ROS_INFO_STREAM("Modified options");
+  descartes_core::RobotModelOptions mod_options = descartes_model_->getOptions();
+  for(auto opt : options)
+  {
+    EXPECT_TRUE(mod_options[opt.first] == opt.second);
+    ROS_INFO_STREAM("option name: "<<opt.first<<", value: "<<opt.second);
+  }
+
   return descartes_model_;
 }
 

--- a/descartes_moveit/test/moveit_state_adapter_test.cpp
+++ b/descartes_moveit/test/moveit_state_adapter_test.cpp
@@ -49,27 +49,9 @@ RobotModelPtr CreateRobotModel<descartes_moveit::MoveitStateAdapter>()
   EXPECT_TRUE(descartes_model_->initialize("robot_description","manipulator","base_link","tool0"));
   ROS_INFO_STREAM("Descartes robot model constructed");
 
-  // getting default options
-  descartes_core::RobotModelOptions options = descartes_model_->getOptions();
-
-  ROS_INFO_STREAM("Default options");
-  for(auto opt : options)
-  {
-    ROS_INFO_STREAM("option name: "<<opt.first<<", value: "<<opt.second);
-  }
-
-  // setting options
-  options["sampled_iterations"] = std::to_string(20);
-  options["check_collisions"] = std::to_string(false);
-  EXPECT_TRUE(descartes_model_->setOptions(options));
-
-  ROS_INFO_STREAM("Modified options");
-  descartes_core::RobotModelOptions mod_options = descartes_model_->getOptions();
-  for(auto opt : options)
-  {
-    EXPECT_TRUE(mod_options[opt.first] == opt.second);
-    ROS_INFO_STREAM("option name: "<<opt.first<<", value: "<<opt.second);
-  }
+  descartes_model_->setCheckCollisions(true);
+  EXPECT_TRUE(descartes_model_->getCheckCollisions());
+  ROS_INFO_STREAM("Descartes robot enabled collision checks");
 
   return descartes_model_;
 }

--- a/descartes_moveit/test/moveit_state_adapter_test.cpp
+++ b/descartes_moveit/test/moveit_state_adapter_test.cpp
@@ -42,20 +42,23 @@ robot_model_loader::RobotModelLoaderPtr robot_;
 template <>
 RobotModelPtr CreateRobotModel<descartes_moveit::MoveitStateAdapter>()
 {
-  robot_model::RobotModelPtr moveit_model_;
-  robot_state::RobotStatePtr state_;
-  descartes_core::RobotModelPtr descartes_model_;
+  //robot_model::RobotModelPtr moveit_model_;
+  //robot_state::RobotStatePtr state_;
 
-  ROS_INFO_STREAM("Loading robot model from parameter");
+/*  ROS_INFO_STREAM("Loading robot model from parameter");
   robot_ = robot_model_loader::RobotModelLoaderPtr(
         new robot_model_loader::RobotModelLoader("robot_description"));
   EXPECT_TRUE(robot_);
+
   ROS_INFO_STREAM("Robot model loaded");
   moveit_model_ = robot_->getModel();
-  state_ = robot_state::RobotStatePtr(new robot_state::RobotState(moveit_model_));
+  state_ = robot_state::RobotStatePtr(new robot_state::RobotState(moveit_model_));*/
+
+
   ROS_INFO_STREAM("Construction descartes robot model");
-  descartes_model_ = descartes_core::RobotModelPtr(
-        new descartes_moveit::MoveitStateAdapter(*state_, "manipulator", "tool0", "base_link"));
+  descartes_core::RobotModelPtr descartes_model_;
+  descartes_model_ = descartes_core::RobotModelPtr(new descartes_moveit::MoveitStateAdapter());
+  EXPECT_TRUE(descartes_model_->initialize("robot_description","manipulator","base_link","tool0"));
   ROS_INFO_STREAM("Descartes robot model constructed");
   return descartes_model_;
 }

--- a/descartes_trajectory/test/cartesian_robot.cpp
+++ b/descartes_trajectory/test/cartesian_robot.cpp
@@ -43,7 +43,6 @@ namespace descartes_trajectory_test
                      << ", orientation: " << orient_range_);
   }
 
-
   bool CartesianRobot::getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const
   {
@@ -68,8 +67,6 @@ namespace descartes_trajectory_test
     return rtn;
   }
 
-
-
   bool CartesianRobot::getAllIK(const Eigen::Affine3d &pose,
                                 std::vector<std::vector<double> > &joint_poses) const
   {
@@ -77,8 +74,6 @@ namespace descartes_trajectory_test
     joint_poses.resize(1);
     return getIK(pose, empty, joint_poses[0]);
   }
-
-
 
   bool CartesianRobot::getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const
   {
@@ -152,15 +147,6 @@ namespace descartes_trajectory_test
     return rtn;
   }
 
-  bool CartesianRobot::setOptions(const descartes_core::RobotModelOptions& options)
-  {
-    return true;
-  }
-
-  descartes_core::RobotModelOptions CartesianRobot::getOptions()
-  {
-    return descartes_core::RobotModelOptions();
-  }
 
 } //descartes_trajectory_test
 

--- a/descartes_trajectory/test/cartesian_robot.cpp
+++ b/descartes_trajectory/test/cartesian_robot.cpp
@@ -64,7 +64,6 @@ namespace descartes_trajectory_test
     else
     {
       rtn = false;
-      ROS_WARN("IK calculated pose, not valid");
     }
     return rtn;
   }
@@ -151,6 +150,16 @@ namespace descartes_trajectory_test
             fabs(Y) <= orient_limit );
 
     return rtn;
+  }
+
+  bool CartesianRobot::setOptions(const descartes_core::RobotModelOptions& options)
+  {
+    return true;
+  }
+
+  descartes_core::RobotModelOptions CartesianRobot::getOptions()
+  {
+    return descartes_core::RobotModelOptions();
   }
 
 } //descartes_trajectory_test

--- a/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
+++ b/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
@@ -49,10 +49,6 @@ public:
 
   virtual int getDOF() const;
 
-  virtual bool setOptions(const descartes_core::RobotModelOptions& options);
-
-  virtual descartes_core::RobotModelOptions getOptions();
-
   virtual bool initialize(const std::string robot_description, const std::string& group_name,
                                          const std::string& world_frame,const std::string& tcp_frame);
   double pos_range_;

--- a/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
+++ b/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
@@ -49,6 +49,10 @@ public:
 
   virtual int getDOF() const;
 
+  virtual bool setOptions(const descartes_core::RobotModelOptions& options);
+
+  virtual descartes_core::RobotModelOptions getOptions();
+
   virtual bool initialize(const std::string robot_description, const std::string& group_name,
                                          const std::string& world_frame,const std::string& tcp_frame);
   double pos_range_;


### PR DESCRIPTION
This PR should be reviewed after #49 is accepted.
- It addresses the issue described in #50 regarding collision checks.
- In addition to that, it added two interface methods for the descartes_core::RobotModel  for setting and getting a map containing option key/value pairs.  
- The constructor for the MoveitStateAdapter no longer takes any initialization arguments, instead it takes them in the 'initialize(..)' interface method.
- The unit test have been updated to conform to the changes above.
