### PR TITLE
Parallel IK Calculations

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
+#find_package(Eigen REQUIRED)
 
 
 catkin_package(

--- a/descartes_core/include/descartes_core/planning_graph.h
+++ b/descartes_core/include/descartes_core/planning_graph.h
@@ -82,7 +82,7 @@ class PlanningGraph
 {
 public:
   // TODO: add constructor that takes RobotState as param
-  PlanningGraph(RobotModelConstPtr &model);
+  PlanningGraph(RobotModelConstPtr model, unsigned max_threads = 4);
 
   virtual ~PlanningGraph();
 
@@ -128,6 +128,8 @@ protected:
   RobotModelConstPtr robot_model_;
 
   JointGraph dg_;
+
+  unsigned max_threads_;
 
   int recalculateJointSolutionsVertexMap(std::map<TrajectoryPt::ID, JointGraph::vertex_descriptor> &joint_vertex_map);
 

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -108,6 +108,8 @@ public:
    */
   virtual bool isValid(const Eigen::Affine3d &pose) const = 0;
 
+  virtual RobotModelPtr clone() const = 0;
+
 };
 
 }//descartes_core

--- a/descartes_core/src/planning_graph.cpp
+++ b/descartes_core/src/planning_graph.cpp
@@ -45,9 +45,9 @@ namespace
   using ConstTrajectorIterator = std::vector<descartes_core::TrajectoryPtPtr>::const_iterator;
 
   VecJointSolutions
-  calculateJointSolutions(descartes_core::RobotModelPtr model, 
-                          ConstTrajectorIterator begin,
-                          ConstTrajectorIterator end)
+  rangeCalculateJointSolutions(descartes_core::RobotModelPtr model, 
+                               ConstTrajectorIterator begin,
+                               ConstTrajectorIterator end)
   {
     VecJointSolutions solutions;
     solutions.reserve(std::distance(begin, end));
@@ -91,7 +91,7 @@ namespace
       // Create a seperate copy of the robot state for this worker
       descartes_core::RobotModelPtr state_copy = model.clone();
       // Launch task
-      futures[i] = std::async(std::launch::async, calculateJointSolutions, state_copy, start, end);
+      futures[i] = std::async(std::launch::async, rangeCalculateJointSolutions, state_copy, start, end);
     }
 
     // Wait for solutions

--- a/descartes_core/src/planning_graph.cpp
+++ b/descartes_core/src/planning_graph.cpp
@@ -65,7 +65,7 @@ namespace
   }
 
   VecJointSolutions
-  parallelCalculateJointSolutions(const std::vector<descartes_core::TrajectoryPtPtr> trajectory,
+  parallelCalculateJointSolutions(const std::vector<descartes_core::TrajectoryPtPtr>& trajectory,
                                   const descartes_core::RobotModel& model,
                                   const unsigned max_threads)
   {

--- a/descartes_core/src/planning_graph.cpp
+++ b/descartes_core/src/planning_graph.cpp
@@ -29,12 +29,85 @@
 #include <iostream>
 #include <utility>
 #include <algorithm>
-#include <fstream>
 
 #include <ros/console.h>
 
 #include <boost/uuid/uuid_io.hpp> // streaming operators
 #include <boost/graph/dijkstra_shortest_paths.hpp>
+
+#include <future>
+
+
+namespace
+{
+  using JointSolutions = std::vector<std::vector<double>>;
+  using VecJointSolutions = std::vector<JointSolutions>;
+  using ConstTrajectorIterator = std::vector<descartes_core::TrajectoryPtPtr>::const_iterator;
+
+  VecJointSolutions
+  calculateJointSolutions(descartes_core::RobotModelPtr model, 
+                          ConstTrajectorIterator begin,
+                          ConstTrajectorIterator end)
+  {
+    VecJointSolutions solutions;
+    solutions.reserve(std::distance(begin, end));
+
+    while (begin != end)
+    {
+      JointSolutions joint_poses;
+      begin->get()->getJointPoses(*model, joint_poses);
+
+      solutions.push_back(std::move(joint_poses));
+      ++begin;
+    }
+
+    return solutions;
+  }
+
+  VecJointSolutions
+  parallelCalculateJointSolutions(const std::vector<descartes_core::TrajectoryPtPtr> trajectory,
+                                  const descartes_core::RobotModel& model)
+  {
+    // Should make this a param
+    const static unsigned NUM_THREADS = 4;
+
+    VecJointSolutions solutions;
+    solutions.reserve(trajectory.size());
+
+    // Divide work into chunks
+    const unsigned chunk_size = trajectory.size() / NUM_THREADS;
+    const unsigned chunk_extra = trajectory.size() % NUM_THREADS;
+
+    // Create tasks
+    std::vector<std::future<VecJointSolutions>> futures (NUM_THREADS);
+    for (size_t i = 0; i < futures.size(); ++i)
+    {
+      auto start = trajectory.cbegin() + i * chunk_size;
+      auto end = start + chunk_size;
+
+      // Give extra work to last element
+      if (i == futures.size() - 1) end += chunk_extra;
+
+      // Create a seperate copy of the robot state for this worker
+      descartes_core::RobotModelPtr state_copy = model.clone();
+      // Launch task
+      futures[i] = std::async(std::launch::async, calculateJointSolutions, state_copy, start, end);
+    }
+
+    // Wait for solutions
+    for (auto& future : futures)
+    {
+      auto solution_segment = std::move(future.get());
+      for (auto& sol : solution_segment)
+      {
+        solutions.push_back(std::move(sol));
+      }
+    }
+
+    return solutions;
+  }
+}
+
 
 namespace descartes_core
 {
@@ -805,36 +878,32 @@ bool PlanningGraph::calculateJointSolutions()
     joint_solutions_map_.clear();
   }
 
-  // for each TrajectoryPt, get the available joint solutions
-  for (std::map<TrajectoryPt::ID, CartesianPointInformation>::iterator trajectory_iter = cartesian_point_link_->begin();
-      trajectory_iter != cartesian_point_link_->end(); trajectory_iter++)
+  // Copy trajectory pt ptrs to a vector to be solved in parallel
+  std::vector<TrajectoryPtPtr> trajectory;
+  trajectory.reserve(cartesian_point_link_->size());
+
+  for (const auto& kv : *cartesian_point_link_) // could also use lambda and std::for_each
   {
-    // TODO: copy this block to a function that can be used by add and modify
-    /*************************/
-    std::list<TrajectoryPt::ID> *traj_solutions = new std::list<TrajectoryPt::ID>();
-    std::vector<std::vector<double> > joint_poses;
-    trajectory_iter->second.source_trajectory_.get()->getJointPoses(*robot_model_, joint_poses);
+    trajectory.push_back(kv.second.source_trajectory_);
+  }
+  
+  // Compute joint solutions for trajectory pts
+  VecJointSolutions all_joint_solutions = parallelCalculateJointSolutions(trajectory, *robot_model_);
 
-    TrajectoryPt::ID tempID = trajectory_iter->first;
-    ROS_INFO("CartID: %s: JointPoses count:%i", boost::uuids::to_string(tempID).c_str(), (int)(joint_poses.size()));
-
-    if (joint_poses.size() == 0)
+  // Create corresponding JointTrajPts for each solution and add them to the joint solutions map
+  size_t idx = 0; // for looking into the solutions array
+  for (auto& kv : *cartesian_point_link_)
+  {
+    std::list<TrajectoryPt::ID> solution_ids;
+    for (const auto& sol : all_joint_solutions[idx])
     {
-      ROS_WARN("no joint solution for this point... potential discontinuity in the graph");
+      JointTrajectoryPt point (sol);
+      solution_ids.push_back(point.getID());
+      joint_solutions_map_[point.getID()] = point;
     }
-    else
-    {
-      for (std::vector<std::vector<double> >::iterator joint_pose_iter = joint_poses.begin();
-          joint_pose_iter != joint_poses.end(); joint_pose_iter++)
-      {
-        //get UUID from JointTrajPt (convert from std::vector<double>)
-        JointTrajectoryPt *new_pt = new JointTrajectoryPt(*joint_pose_iter);
-        traj_solutions->push_back(new_pt->getID());
-        joint_solutions_map_[new_pt->getID()] = *new_pt;
-      }
-    }
-    trajectory_iter->second.joints_ = *traj_solutions;
-    /*************************/
+    // Update the original trajectory with new info
+    kv.second.joints_ = std::move(solution_ids);
+    ++idx;
   }
 
   return true;

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -63,6 +63,8 @@ public:
 
   virtual int getDOF() const;
 
+  virtual descartes_core::RobotModelPtr clone() const;
+
 protected:
 
   /**

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -28,6 +28,7 @@
 
 namespace descartes_moveit
 {
+  const static double IK_TIMEOUT = 0.05; // seconds
 
 MoveitStateAdapter::MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
                                      const std::string & tool_frame, const std::string & world_frame,
@@ -86,7 +87,7 @@ bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, std::vector<double> 
 
 
   if (robot_state_->setFromIK(robot_state_->getJointModelGroup(group_name_), tool_pose,
-                              tool_frame_, 1, 0.05))
+                              tool_frame_, 1, IK_TIMEOUT))
   {
     robot_state_->copyJointGroupPositions(group_name_, joint_pose);
     rtn = true;
@@ -148,15 +149,15 @@ bool MoveitStateAdapter::getAllIK(const Eigen::Affine3d &pose, std::vector<std::
       }
     }
   }
-  logDebug("Found %d joint solutions out of %d iterations", joint_poses.size(), sample_iterations_);
+  // logDebug("Found %d joint solutions out of %d iterations", joint_poses.size(), sample_iterations_);
   if (joint_poses.empty())
   {
-    logError("Found 0 joint solutions out of %d iterations", sample_iterations_);
+    // logError("Found 0 joint solutions out of %d iterations", sample_iterations_);
     return false;
   }
   else
   {
-    logInform("Found %d joint solutions out of %d iterations", joint_poses.size(), sample_iterations_);
+    // logInform("Found %d joint solutions out of %d iterations", joint_poses.size(), sample_iterations_);
     return true;
   }
 }

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -86,7 +86,7 @@ bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, std::vector<double> 
 
 
   if (robot_state_->setFromIK(robot_state_->getJointModelGroup(group_name_), tool_pose,
-                              tool_frame_))
+                              tool_frame_, 1, 0.05))
   {
     robot_state_->copyJointGroupPositions(group_name_, joint_pose);
     rtn = true;
@@ -235,6 +235,11 @@ int MoveitStateAdapter::getDOF() const
   const moveit::core::JointModelGroup* group;
   group = robot_state_->getJointModelGroup(group_name_);
   return group->getVariableCount();
+}
+
+descartes_core::RobotModelPtr MoveitStateAdapter::clone() const
+{
+  return descartes_core::RobotModelPtr(new MoveitStateAdapter(*robot_state_, group_name_, tool_frame_, world_frame_, sample_iterations_));
 }
 
 } //descartes_moveit


### PR DESCRIPTION
This pull request adds a clone function to the RobotState interface and uses this to do parallel IK calculations in the calculateJointSolutions function.

This is not necessarily the best solution. But it was the quickest and cleanest solution that I could imagine, and I wanted it for my own work. I tested this on an Indigo machine with gcc 4.8 and it makes use of c++11 features (since we were using them already).
