### PR TITLE
Assorted memory leak fixes

### DIFF
--- a/descartes_core/include/descartes_core/planning_graph.h
+++ b/descartes_core/include/descartes_core/planning_graph.h
@@ -102,7 +102,7 @@ public:
 
   bool removeTrajectory(TrajectoryPtPtr point);
 
-  const CartesianMap& getCartesianMap();
+  CartesianMap getCartesianMap();
 
   /** @brief Calculate and return the shortest path from the given joint solution indices
    * @param startIndex The index of the joint solution at which to start


### PR DESCRIPTION
It looks like the original author came from a garbage collected language and thus used a lot of news when stack allocation is probably just fine. I removed most of the news and adjusted syntax accordingly. 

The only significant change was the to the getCartesianMap function whose signature I changed. I'm not sure what the author originally intended so I went with the safest option possible and returned by value. When compiled with the current c++11 flags especially, this shouldn't be too much of a penalty.
