### PR TITLE
Added functions for running IK solutions in multiple threads

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -102,6 +102,8 @@ public:
   virtual bool initialize(const std::string robot_description, const std::string& group_name,
                           const std::string& world_frame,const std::string& tcp_frame) = 0;
 
+  virtual RobotModelPtr clone() const = 0;
+
 protected:
 
   RobotModel(){}

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -71,6 +71,8 @@ public:
 
   virtual int getDOF() const;
 
+  virtual descartes_core::RobotModelPtr clone() const;
+
 protected:
 
   /**

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -28,6 +28,8 @@
 
 const static int SAMPLE_ITERATIONS = 10;
 
+const static double MAX_ITER_SEARCH_TIME = 0.05;
+
 namespace descartes_moveit
 {
 
@@ -137,7 +139,7 @@ bool MoveitStateAdapter::getIK(const Eigen::Affine3d &pose, std::vector<double> 
 
 
   if (robot_state_->setFromIK(robot_state_->getJointModelGroup(group_name_), tool_pose,
-                              tool_frame_))
+                              tool_frame_, 1, MAX_ITER_SEARCH_TIME))
   {
     robot_state_->copyJointGroupPositions(group_name_, joint_pose);
     rtn = true;
@@ -286,6 +288,11 @@ int MoveitStateAdapter::getDOF() const
   const moveit::core::JointModelGroup* group;
   group = robot_state_->getJointModelGroup(group_name_);
   return group->getVariableCount();
+}
+
+descartes_core::RobotModelPtr MoveitStateAdapter::clone() const
+{
+  return descartes_core::RobotModelPtr(new MoveitStateAdapter(*robot_state_, group_name_, tool_frame_, world_frame_, sample_iterations_));
 }
 
 } //descartes_moveit

--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -79,7 +79,7 @@ class PlanningGraph
 {
 public:
   // TODO: add constructor that takes RobotState as param
-  PlanningGraph(descartes_core::RobotModelConstPtr &model);
+  PlanningGraph(descartes_core::RobotModelConstPtr &model, unsigned nthreads = 1);
 
   virtual ~PlanningGraph();
 
@@ -129,6 +129,8 @@ protected:
   descartes_core::RobotModelConstPtr robot_model_;
 
   JointGraph dg_;
+
+  unsigned nthreads_;
 
   int recalculateJointSolutionsVertexMap(std::map<descartes_core::TrajectoryPt::ID, JointGraph::vertex_descriptor> &joint_vertex_map);
 


### PR DESCRIPTION
This is a repeat of pull-request #56. This adds a clone function to the RobotModel interface and spawns a given number of threads each with its own clone of the RobotModel to do IK calculations in parallel. 

By default one thread is used, so multi-threading is opt-in, though new thread and clone are made and the original blocks till the former is done.
