### PR TITLE
Fix for issue #66: force dependant pkgs to enable C++0x/11 support using CFG_EXTRAS

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(descartes_core)
 
-add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
   console_bridge
   moveit_core
@@ -22,6 +21,8 @@ catkin_package(
     Boost
     console_bridge
     Eigen
+  CFG_EXTRAS
+    descartes_core-extras.cmake
 )
 
 ###########

--- a/descartes_core/cmake/descartes_core-extras.cmake
+++ b/descartes_core/cmake/descartes_core-extras.cmake
@@ -1,0 +1,15 @@
+#
+# descartes_core CMake/catkin extras snippet
+#
+# Enable (GCC) C++0x/11 support by adding the corresponding compiler flag
+# directly.
+#
+# TODO: for newer versions of CMake, this should probably be done using
+#       add_compile_options(..) (>= 2.8.11), or target_compile_features(..)
+#       (>= 3.1.x).
+#
+if (NOT descartes_core_FIND_QUIETLY)
+  message(STATUS "descartes_core: enabling C++0x (required)")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(descartes_moveit)
 
-add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   tf
@@ -15,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(rosconsole_bridge REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
-
 
 catkin_package(
   INCLUDE_DIRS

--- a/descartes_planner/CMakeLists.txt
+++ b/descartes_planner/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(descartes_planner)
-add_definitions(-std=gnu++0x)
+
 find_package(catkin REQUIRED COMPONENTS
   descartes_core
   descartes_trajectory
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   pluginlib
 )
+
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
 

--- a/descartes_trajectory/CMakeLists.txt
+++ b/descartes_trajectory/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(descartes_trajectory)
-add_definitions(-std=gnu++0x)
+
 find_package(catkin REQUIRED COMPONENTS
   console_bridge
   descartes_core


### PR DESCRIPTION
As per subject.

Dependants `find_package(..)`-ing any package in `descartes` will see the following message printed in the CMake configuration phase:

```
-- descartes_core: enabling C++0x (required)
```

Contrary to what I wrote in #66, I opted to directly append the flag to the `CMAKE_CXX_FLAGS`, as it is always used irrespective of build type, and avoids users forgetting to add the exported definitions in their `CMakeLists.txt` (although that would lead to highly visible compiler errors).

I also did not export the `-std=c++0x` flag in every `descartes` pkg, as it is impossible to depend on any of `descartes`' pkgs without also depending on `descartes_core`, which already exports that flag.

Finally, I think it's considered bad practice to rely on a dependency for setting option flags in dependants, so having this exported does _not_ mean that dependants should not enable C++0x/11 support by themselves if they need it for their own sources (so pkgs in `godel` should still enable it in their `CMakeLists.txt` if they need it).

This is only meant to make sure that dependants do not have to worry about what flags `descartes` needs, if they use it.
