### PR TITLE
Robot Description Argument Taken By Reference (Issue #70)

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -99,7 +99,7 @@ public:
    * @param tcp_frame tool link attached to the robot. When it's not in 'group_name' then it should have
    * a fixed location relative to the last link in 'group_name'.
    */
-  virtual bool initialize(const std::string robot_description, const std::string& group_name,
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& world_frame,const std::string& tcp_frame) = 0;
 
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -56,7 +56,7 @@ public:
   {
   }
 
-  virtual bool initialize(const std::string robot_description, const std::string& group_name,
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& world_frame,const std::string& tcp_frame);
 
   virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -77,7 +77,7 @@ MoveitStateAdapter::MoveitStateAdapter(const moveit::core::RobotState & robot_st
   return;
 }
 
-bool MoveitStateAdapter::initialize(const std::string robot_description, const std::string& group_name,
+bool MoveitStateAdapter::initialize(const std::string& robot_description, const std::string& group_name,
                                     const std::string& world_frame,const std::string& tcp_frame)
 {
 

--- a/descartes_trajectory/test/cartesian_robot.cpp
+++ b/descartes_trajectory/test/cartesian_robot.cpp
@@ -30,8 +30,8 @@ namespace descartes_trajectory_test
                      << ", orientation: " << orient_range_);
   }
 
-  bool CartesianRobot::initialize(const std::string robot_description, const std::string& group_name,
-                          const std::string& world_frame,const std::string& tcp_frame)
+  bool CartesianRobot::initialize(const std::string& robot_description, const std::string& group_name,
+                                  const std::string& world_frame,const std::string& tcp_frame)
   {
     return true;
   }

--- a/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
+++ b/descartes_trajectory/test/descartes_trajectory_test/cartesian_robot.h
@@ -49,8 +49,8 @@ public:
 
   virtual int getDOF() const;
 
-  virtual bool initialize(const std::string robot_description, const std::string& group_name,
-                                         const std::string& world_frame,const std::string& tcp_frame);
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
+                          const std::string& world_frame,const std::string& tcp_frame);
   double pos_range_;
   double orient_range_;
   int dof_;


### PR DESCRIPTION
This is a small fix going inline with issue #70. It changes the robot_description argument to by taken by reference like the other arguments of the Initialize function.
