### PR TITLE
Fix indigo build issues

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -3,14 +3,13 @@ project(descartes_core)
 
 add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
-  console_bridge
   moveit_core
   roscpp
+  cmake_modules
 )
 
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
-
 
 catkin_package(
   INCLUDE_DIRS
@@ -20,7 +19,6 @@ catkin_package(
     moveit_core
   DEPENDS
     Boost
-    console_bridge
     Eigen
 )
 

--- a/descartes_core/package.xml
+++ b/descartes_core/package.xml
@@ -17,6 +17,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>moveit_core</run_depend>

--- a/descartes_core/package.xml
+++ b/descartes_core/package.xml
@@ -14,12 +14,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
-  <build_depend>console_bridge</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <run_depend>boost</run_depend>
-  <run_depend>console_bridge</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
 

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -17,6 +17,7 @@
   <build_depend>descartes_trajectory</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>rosconsole_bridge</run_depend>
   <run_depend>moveit_core</run_depend>

--- a/descartes_planner/CMakeLists.txt
+++ b/descartes_planner/CMakeLists.txt
@@ -4,10 +4,10 @@ add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
   descartes_core
   descartes_trajectory
-  console_bridge
   moveit_core
   roscpp
   pluginlib
+  cmake_modules
 )
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
@@ -24,9 +24,10 @@ catkin_package(
   CATKIN_DEPENDS
     roscpp
     moveit_core
+    descartes_core
+    descartes_trajectory
   DEPENDS
     Boost
-    console_bridge
     Eigen
 )
 

--- a/descartes_planner/package.xml
+++ b/descartes_planner/package.xml
@@ -11,15 +11,14 @@
   <build_depend>descartes_core</build_depend>
   <build_depend>descartes_trajectory</build_depend>
   <build_depend>boost</build_depend>
-  <build_depend>console_bridge</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <run_depend>descartes_core</run_depend>
   <run_depend>descartes_trajectory</run_depend>
   <run_depend>boost</run_depend>
-  <run_depend>console_bridge</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>

--- a/descartes_planner/package.xml
+++ b/descartes_planner/package.xml
@@ -15,6 +15,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>descartes_core</run_depend>
   <run_depend>descartes_trajectory</run_depend>

--- a/descartes_trajectory/CMakeLists.txt
+++ b/descartes_trajectory/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(descartes_trajectory)
 add_definitions(-std=gnu++0x)
 find_package(catkin REQUIRED COMPONENTS
-  console_bridge
+  cmake_modules
   descartes_core
   moveit_core
   roscpp
@@ -23,9 +23,9 @@ catkin_package(
   CATKIN_DEPENDS
     roscpp
     moveit_core
+    descartes_core
   DEPENDS
     Boost
-    console_bridge
     Eigen
 )
 

--- a/descartes_trajectory/package.xml
+++ b/descartes_trajectory/package.xml
@@ -8,13 +8,11 @@
   <author email="jnicho@swri.org">Jorge Nicho</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>boost</build_depend>
-  <build_depend>console_bridge</build_depend>
   <build_depend>descartes_core</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
-  <run_depend>boost</run_depend>
-  <run_depend>console_bridge</run_depend>
+  <build_depend>cmake_modules</build_depend>
+
   <run_depend>descartes_core</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>

--- a/descartes_trajectory/package.xml
+++ b/descartes_trajectory/package.xml
@@ -12,6 +12,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>descartes_core</run_depend>
   <run_depend>moveit_core</run_depend>


### PR DESCRIPTION
@shaun-edwards, the changes in this PR fix the build errors in ros-indigo.  You could either merge this and/or use it as a departure point for the **indigo-devel** branch.
