### PR TITLE
Trajectory Discretization Unit Tests (Joint Trajectory Point)

### DIFF
--- a/descartes_trajectory/test/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/test/cart_trajectory_pt.cpp
@@ -77,7 +77,7 @@ TEST(CartTrajPt, getPoses)
   std::vector<std::vector<double> >joint_solutions;
 
   ROS_INFO_STREAM("Testing fuzzy pos point");
-  CartesianRobot robot(POS_TOL+2*EPSILON, ORIENT_TOL+2*EPSILON);
+  CartesianRobot robot(POS_TOL+2*EPSILON, M_PI*ORIENT_TOL+2*EPSILON);
   fuzzy_pos.getCartesianPoses(robot, solutions);
   EXPECT_EQ(solutions.size(), NUM_SAMPLED_POS);
   fuzzy_pos.getJointPoses(robot,joint_solutions);

--- a/descartes_trajectory/test/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/test/cart_trajectory_pt.cpp
@@ -77,7 +77,7 @@ TEST(CartTrajPt, getPoses)
   std::vector<std::vector<double> >joint_solutions;
 
   ROS_INFO_STREAM("Testing fuzzy pos point");
-  CartesianRobot robot(POS_TOL+2*EPSILON, M_PI*ORIENT_TOL+2*EPSILON);
+  CartesianRobot robot(POS_TOL+2*EPSILON, 2*M_PI+2*EPSILON);
   fuzzy_pos.getCartesianPoses(robot, solutions);
   EXPECT_EQ(solutions.size(), NUM_SAMPLED_POS);
   fuzzy_pos.getJointPoses(robot,joint_solutions);

--- a/descartes_trajectory/test/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/test/cart_trajectory_pt.cpp
@@ -38,8 +38,8 @@ TEST(CartTrajPt, getPoses)
   const double POS_TOL = 2.0;
   const double POS_INC = 0.2;
 
-  const double ORIENT_TOL = 1.0;
-  const double ORIENT_INC = 0.2;
+  const double ORIENT_TOL = 2*M_PI;
+  const double ORIENT_INC = M_PI/4;
 
   const double EPSILON = 0.001;
 
@@ -77,7 +77,7 @@ TEST(CartTrajPt, getPoses)
   std::vector<std::vector<double> >joint_solutions;
 
   ROS_INFO_STREAM("Testing fuzzy pos point");
-  CartesianRobot robot(POS_TOL+2*EPSILON, 2*M_PI+2*EPSILON);
+  CartesianRobot robot(POS_TOL+2*EPSILON, ORIENT_TOL+2*EPSILON);
   fuzzy_pos.getCartesianPoses(robot, solutions);
   EXPECT_EQ(solutions.size(), NUM_SAMPLED_POS);
   fuzzy_pos.getJointPoses(robot,joint_solutions);

--- a/descartes_trajectory/test/descartes_trajectory_test/robot_model_test.hpp
+++ b/descartes_trajectory/test/descartes_trajectory_test/robot_model_test.hpp
@@ -51,7 +51,7 @@ public:
   virtual void SetUp()
   {
     ROS_INFO("Setting up RobotModelTest fixture(base) (parameterized)");
-    ASSERT_TRUE(this->model_);
+    ASSERT_TRUE(static_cast<bool>(this->model_));
   }
 
   virtual void TearDown()


### PR DESCRIPTION
This pull request changes the settings of Cartesian Robot in a particular unit test to accept any joint values. Please see issue #73.
