### PR TITLE
Issue #78 shared pointer usage in planners

### DIFF
--- a/descartes_core/include/descartes_core/path_planner_base.h
+++ b/descartes_core/include/descartes_core/path_planner_base.h
@@ -51,7 +51,7 @@ public:
    * @param model robot model implementation for which to plan a path
    * @param config A map containing the parameter/value pairs.
    */
-  virtual bool initialize(RobotModelConstPtr &model) = 0;
+  virtual bool initialize(RobotModelConstPtr model) = 0;
 
   /**
    * @brief Configure the planner's parameters. Should return 'true' when all the entries were properly parsed.

--- a/descartes_planner/include/descartes_planner/dense_planner.h
+++ b/descartes_planner/include/descartes_planner/dense_planner.h
@@ -21,7 +21,7 @@ public:
 
   virtual ~DensePlanner();
 
-  virtual bool initialize(descartes_core::RobotModelConstPtr &model);
+  virtual bool initialize(descartes_core::RobotModelConstPtr model);
   virtual bool setConfig(const descartes_core::PlannerConfig& config);
   virtual void getConfig(descartes_core::PlannerConfig& config) const;
   virtual bool planPath(const std::vector<descartes_core::TrajectoryPtPtr>& traj);

--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -79,7 +79,7 @@ class PlanningGraph
 {
 public:
   // TODO: add constructor that takes RobotState as param
-  PlanningGraph(descartes_core::RobotModelConstPtr &model);
+  PlanningGraph(descartes_core::RobotModelConstPtr model);
 
   virtual ~PlanningGraph();
 

--- a/descartes_planner/include/descartes_planner/sparse_planner.h
+++ b/descartes_planner/include/descartes_planner/sparse_planner.h
@@ -38,11 +38,11 @@ class SparsePlanner: public descartes_core::PathPlannerBase
 public:
   typedef std::vector<std::tuple<int,descartes_core::TrajectoryPtPtr,descartes_trajectory::JointTrajectoryPt> > SolutionArray;
 public:
-  SparsePlanner(descartes_core::RobotModelConstPtr &model,double sampling = 0.1f);
+  SparsePlanner(descartes_core::RobotModelConstPtr model,double sampling = 0.1f);
   SparsePlanner();
   virtual ~SparsePlanner();
 
-  virtual bool initialize(descartes_core::RobotModelConstPtr &model);
+  virtual bool initialize(descartes_core::RobotModelConstPtr model);
   virtual bool setConfig(const descartes_core::PlannerConfig& config);
   virtual void getConfig(descartes_core::PlannerConfig& config) const;
   virtual bool planPath(const std::vector<descartes_core::TrajectoryPtPtr>& traj);

--- a/descartes_planner/src/dense_planner.cpp
+++ b/descartes_planner/src/dense_planner.cpp
@@ -31,10 +31,10 @@ DensePlanner::~DensePlanner()
 
 }
 
-bool DensePlanner::initialize(descartes_core::RobotModelConstPtr &model)
+bool DensePlanner::initialize(descartes_core::RobotModelConstPtr model)
 {
   planning_graph_ = boost::shared_ptr<descartes_planner::PlanningGraph>(
-      new descartes_planner::PlanningGraph(model));
+      new descartes_planner::PlanningGraph(std::move(model));
   error_code_ = descartes_core::PlannerErrors::EMPTY_PATH;
   return true;
 }

--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -44,8 +44,8 @@ namespace descartes_planner
 const double MAX_JOINT_DIFF = M_PI;
 const double MAX_EXCEEDED_PENALTY = 10000.0f;
 
-PlanningGraph::PlanningGraph(RobotModelConstPtr &model)
-  : robot_model_(model)
+PlanningGraph::PlanningGraph(RobotModelConstPtr model)
+  : robot_model_(std::move(model))
   , cartesian_point_link_(NULL)
 {}
 

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -36,7 +36,7 @@ const double MAX_JOINT_CHANGE = M_PI_4;
 const double DEFAULT_SAMPLING = 0.1f;
 const std::string SAMPLING_CONFIG = "sampling";
 
-SparsePlanner::SparsePlanner(RobotModelConstPtr &model,double sampling):
+SparsePlanner::SparsePlanner(RobotModelConstPtr model,double sampling):
     sampling_(sampling),
     error_code_(descartes_core::PlannerError::UNINITIALIZED)
 {
@@ -49,7 +49,7 @@ SparsePlanner::SparsePlanner(RobotModelConstPtr &model,double sampling):
                  {PlannerError::INCOMPLETE_PATH,"Input trajectory and output path point cound differ"}
                };
 
-  initialize(model);
+  initialize(std::move(model);
   config_ = {{SAMPLING_CONFIG,std::to_string(sampling)}};
 }
 
@@ -69,9 +69,9 @@ SparsePlanner::SparsePlanner():
   config_ = {{SAMPLING_CONFIG,std::to_string(DEFAULT_SAMPLING)}};
 }
 
-bool SparsePlanner::initialize(RobotModelConstPtr &model)
+bool SparsePlanner::initialize(RobotModelConstPtr model)
 {
-  planning_graph_ = boost::shared_ptr<descartes_planner::PlanningGraph>(new descartes_planner::PlanningGraph(model));
+  planning_graph_ = boost::shared_ptr<descartes_planner::PlanningGraph>(new descartes_planner::PlanningGraph(std::move(model));
   error_code_ = PlannerError::EMPTY_PATH;
   return true;
 }


### PR DESCRIPTION
"The fix is to simply take the shared pointer by value and use std::move (since we're in c++11 land now) to get it all the way down the chain to planning graph." Implemented in planning_graph, dense and sparse planners and their header files. 
