### PR TITLE
Incorrect cartesian point discretization 

### DIFF
--- a/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
@@ -304,6 +304,10 @@ public:
 
 
 protected:
+
+  bool computeCartesianPoses(EigenSTL::vector_Affine3d& poses) const;
+
+protected:
   descartes_core::Frame                         tool_base_;     /**<@brief Fixed transform from wrist/tool_plate to tool base. */
   TolerancedFrame               tool_pt_;       /**<@brief Underconstrained transform from tool_base to effective pt on tool. */
   descartes_core::Frame                         wobj_base_;     /**<@brief Fixed transform from WCS to base of object. */

--- a/descartes_trajectory/src/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/src/cart_trajectory_pt.cpp
@@ -215,7 +215,7 @@ void CartTrajectoryPt::getCartesianPoses(const RobotModel &model, EigenSTL::vect
   if(computeCartesianPoses(all_poses))
   {
     poses.reserve(all_poses.size());
-    for(auto pose: all_poses)
+    for(const auto& pose: all_poses)
     {
       if(model.isValid(pose))
       {
@@ -337,7 +337,7 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model,
   if(computeCartesianPoses(poses))
   {
     poses.reserve(poses.size());
-    for(auto pose: poses)
+    for(const auto& pose: poses)
     {
       std::vector<std::vector<double> > local_joint_poses;
       if(model.getAllIK(pose, local_joint_poses))

--- a/descartes_trajectory/src/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/src/cart_trajectory_pt.cpp
@@ -184,29 +184,60 @@ bool CartTrajectoryPt::getNominalCartPose(const std::vector<double> &seed_state,
   return true;  //TODO can this ever return false?
 }
 
-void CartTrajectoryPt::getCartesianPoses(const RobotModel &model, EigenSTL::vector_Affine3d &poses) const
+bool CartTrajectoryPt::computeCartesianPoses(EigenSTL::vector_Affine3d &poses) const
 {
-  poses.clear();
   EigenSTL::vector_Affine3d sampled_wobj_pts = uniform(wobj_pt_, orient_increment_,
                                                      pos_increment_);
-  poses.reserve(sampled_wobj_pts.size());
+  EigenSTL::vector_Affine3d sampled_tool_pts = uniform(tool_pt_, orient_increment_,
+                                                       pos_increment_);
+
+  poses.clear();
+  poses.reserve(sampled_wobj_pts.size()*sampled_tool_pts.size());
   for(size_t wobj_pt = 0; wobj_pt < sampled_wobj_pts.size(); ++wobj_pt)
   {
-    Eigen::Affine3d pose = wobj_base_.frame * sampled_wobj_pts[wobj_pt];
-    if(model.isValid(pose))
+    for(size_t tool_pt = 0; tool_pt < sampled_tool_pts.size(); ++tool_pt)
     {
+      Eigen::Affine3d pose = wobj_base_.frame * sampled_wobj_pts[wobj_pt] *
+          sampled_tool_pts[tool_pt].inverse() * tool_base_.frame_inv;
+
       poses.push_back(pose);
     }
   }
-  if( poses.empty())
+
+  return !poses.empty();
+}
+
+void CartTrajectoryPt::getCartesianPoses(const RobotModel &model, EigenSTL::vector_Affine3d &poses) const
+{
+  EigenSTL::vector_Affine3d all_poses;
+  poses.clear();
+
+  if(computeCartesianPoses(all_poses))
   {
-    ROS_WARN("Failed for find ANY cartesian poses, returning");
+    poses.reserve(all_poses.size());
+    for(auto pose: all_poses)
+    {
+      if(model.isValid(pose))
+      {
+        poses.push_back(pose);
+      }
+    }
   }
   else
   {
-    ROS_DEBUG_STREAM("Get cartesian poses, sampled: " << sampled_wobj_pts.size()
+    ROS_ERROR("Failed for find ANY cartesian poses");
+  }
+
+  if( poses.empty())
+  {
+    ROS_WARN("Failed for find VALID cartesian poses, returning");
+  }
+  else
+  {
+    ROS_DEBUG_STREAM("Get cartesian poses, sampled: " << all_poses.size()
                      << ", with " << poses.size() << " valid(returned) poses");
   }
+
 }
 
 bool CartTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_state,
@@ -301,18 +332,13 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model,
                                      std::vector<std::vector<double> > &joint_poses) const
 {
   joint_poses.clear();
-  EigenSTL::vector_Affine3d sampled_wobj_pts = uniform(wobj_pt_, orient_increment_,
-                                                     pos_increment_);
-  EigenSTL::vector_Affine3d sampled_tool_pts = uniform(tool_pt_, orient_increment_,
-                                                       pos_increment_);
-  size_t sample_size = sampled_wobj_pts.size() * sampled_tool_pts.size();
-  joint_poses.reserve(sample_size);
-  for(size_t wobj_pt = 0; wobj_pt < sampled_wobj_pts.size(); ++wobj_pt)
+
+  EigenSTL::vector_Affine3d poses;
+  if(computeCartesianPoses(poses))
   {
-    for(size_t tool_pt = 0; tool_pt < sampled_tool_pts.size(); ++tool_pt)
+    poses.reserve(poses.size());
+    for(auto pose: poses)
     {
-      Eigen::Affine3d pose = wobj_base_.frame * sampled_wobj_pts[wobj_pt] *
-          sampled_tool_pts[tool_pt].inverse() * tool_base_.frame_inv;
       std::vector<std::vector<double> > local_joint_poses;
       if(model.getAllIK(pose, local_joint_poses))
       {
@@ -320,13 +346,18 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model,
       }
     }
   }
+  else
+  {
+    ROS_ERROR("Failed for find ANY cartesian poses");
+  }
+
   if( joint_poses.empty())
   {
     ROS_WARN("Failed for find ANY joint poses, returning");
   }
   else
   {
-    ROS_DEBUG_STREAM("Get joint poses, sampled: " << sample_size
+    ROS_DEBUG_STREAM("Get joint poses, sampled: " << poses.size()
                      << ", with " << joint_poses.size() << " valid(returned) poses");
   }
 }


### PR DESCRIPTION
This is the fix for issue #84 
The discretization of the cartesian poses is now done in the **computeCartesianPoses** method which is invoked by the two method (getJointPoses and getCartesianPoses) that need this result.
