### PR TITLE
Updated doxygen files

### DIFF
--- a/descartes_core/mainpage.dox
+++ b/descartes_core/mainpage.dox
@@ -1,0 +1,21 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b descartes_core defines the abstract interfaces for the core descartes concepts of robot models, trajectory points, and path planners.
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+
+The main APIs of are largely captured in the following interface classes:
+- descartes_core::TrajectoryPt : Defines the interface for a descartes trajectory point. Emodies the logic of how to search for valid joint solutions.
+
+- descartes_core::RobotModel : Defines the interface for a descartes robot model. These models embody the kinematics of the robot. They are used to do forward and inverse kinematics and are also responsible for checking the validity of positions and movements.
+
+- descartes_core::PathPlannerBase : Defines the interface to a descartes path planner. Planners are responsible for transforming a sequence of trajectory points into a meaningful sequence of joint positions. 
+
+*/

--- a/descartes_core/package.xml
+++ b/descartes_core/package.xml
@@ -26,5 +26,6 @@
   <test_depend>rosunit</test_depend>
 
   <export>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/descartes_core/rosdoc.yaml
+++ b/descartes_core/rosdoc.yaml
@@ -1,0 +1,2 @@
+- builder: doxygen
+  exclude_symbols: pretty_print*

--- a/descartes_moveit/mainpage.dox
+++ b/descartes_moveit/mainpage.dox
@@ -1,0 +1,15 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b descartes_moveit provides a reference implementation of a descartes_core::RobotModel using MoveIt! to perform the math for a generic robot.
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+- descartes_moveit::MoveitStateAdapter : This class provides a reference implementation of a descartes_core::RobotModel using Moveit! to perform the underlying calculations. Not thread safe.
+
+*/

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -32,5 +32,6 @@
 
   <export>
     <descartes_core plugin="${prefix}/moveit_adapter_plugins.xml"/>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/descartes_moveit/rosdoc.yaml
+++ b/descartes_moveit/rosdoc.yaml
@@ -1,0 +1,2 @@
+- builder: doxygen
+  exclude_symbols: pretty_print*

--- a/descartes_planner/mainpage.dox
+++ b/descartes_planner/mainpage.dox
@@ -1,0 +1,18 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b descartes_planner provides reference implementations of descartes_core::PathPlannerBase.
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+This package offers the following path planners:
+- descartes_planner::DensePlanner : DensePlanner takes a brute force approach to finding a sequence of joint solutions that defines an "optimum" path through a sequence of input descartes_core::TrajectoryPt's. Optimum is defined as the path with minimal joint changes. It works by expanding all of the valid inverse kinematic solutions for every trajectory point passed in. Edges are added between every possible pair of solutions from contigous user trajectory points. Dijkstra's algorithm is then used to find a path with minimal joint motion through the graph.
+
+- descartes_planner::SparsePlanner : SparsePlanner attempts to optimize the process used by DensePlanner by not expanding every point. Instead a subset of the points are expanded and the planner attempts to use joint interpolation to find a satisfactory solution to the not-expanded points (thereby reducing the number of IK solutions required). 
+
+*/

--- a/descartes_planner/package.xml
+++ b/descartes_planner/package.xml
@@ -26,5 +26,6 @@
 
   <export>
     <descartes_core plugin="${prefix}/descartes_planner_plugins.xml"/>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/descartes_planner/rosdoc.yaml
+++ b/descartes_planner/rosdoc.yaml
@@ -1,0 +1,2 @@
+- builder: doxygen
+  exclude_symbols: pretty_print*

--- a/descartes_trajectory/mainpage.dox
+++ b/descartes_trajectory/mainpage.dox
@@ -1,0 +1,17 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b descartes_trajectory provides reference implementations of descartes_core::TrajectoryPt for common use cases.
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+The reference implementations are:
+- descartes_trajectory::CartTrajectoryPt : A trajectory point representing a 6D cartesian pose, possibly with some tolerances. Points in cartesian space are sampled and then expanded into (possibly many) joint solutions using descartes_core::RobotModel.
+- descartes_trajectory::JointTrajectoryPt : A trajectory point representing the specification of the position of all active joints on the robot, optionally with tolerances. 
+
+*/

--- a/descartes_trajectory/package.xml
+++ b/descartes_trajectory/package.xml
@@ -19,5 +19,6 @@
   <run_depend>roscpp</run_depend>
 
   <export>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/descartes_trajectory/rosdoc.yaml
+++ b/descartes_trajectory/rosdoc.yaml
@@ -1,0 +1,2 @@
+- builder: doxygen
+  exclude_symbols: pretty_print*


### PR DESCRIPTION
This PR adds mainpage doxygen files for each of the major packages. It also adds rosdoc configurations (and associated export tags) that ignore the pretty print library.
