### PR TITLE
Issue#77 uuid replacement

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS
     include
+  LIBRARIES
+    descartes_core
   CATKIN_DEPENDS
     roscpp
     moveit_core
@@ -31,4 +33,13 @@ include_directories(include
                     ${Boost_INCLUDE_DIRS}
                     ${Eigen_INCLUDE_DIRS}
 )
+
+add_library(descartes_core
+            src/trajectory_id.cpp
+)
+
+target_link_libraries(descartes_core
+                      ${catkin_LIBRARIES}
+)
+
 

--- a/descartes_core/include/descartes_core/trajectory_id.h
+++ b/descartes_core/include/descartes_core/trajectory_id.h
@@ -1,0 +1,102 @@
+#ifndef TRAJECTORY_ID_H
+#define TRAJECTORY_ID_H
+
+#include <boost/atomic.hpp>
+#include <iostream>
+
+namespace descartes_core
+{
+
+template<typename T>
+struct IdGenerator;
+
+template<>
+struct IdGenerator<uint64_t>
+{
+  typedef uint64_t value_type;
+
+  static value_type make_nil()
+  {
+    return 0;
+  }
+
+  static value_type make_id()
+  {
+    return counter_++;
+  }
+
+  static bool is_nil(value_type id)
+  {
+    return id == 0;
+  }
+
+private:
+  static boost::atomic<value_type> counter_;
+};
+
+template<typename T>
+class TrajectoryID_
+{
+public:
+  typedef T value_type;
+
+  TrajectoryID_(value_type id)
+    : id_(id)
+  {}
+
+  TrajectoryID_()
+  {}
+
+  bool is_nil() const { return IdGenerator<value_type>::is_nil(id_); }
+
+  value_type value() const { return id_; }
+
+  static TrajectoryID_<value_type> make_id()
+  {
+    return TrajectoryID_<value_type>( IdGenerator<value_type>::make_id() );
+  }
+
+  static TrajectoryID_<value_type> make_nil()
+  {
+    return TrajectoryID_<value_type>( IdGenerator<value_type>::make_nil() );
+  }
+
+private:
+  value_type id_;  
+};
+
+//////////////////////
+// Helper Functions //
+//////////////////////
+
+template<typename T>
+inline bool operator==(TrajectoryID_<T> lhs, TrajectoryID_<T> rhs)
+{
+  return lhs.value() == rhs.value();
+}
+
+template<typename T>
+inline bool operator!=(TrajectoryID_<T> lhs, TrajectoryID_<T> rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<typename T>
+inline bool operator<(TrajectoryID_<T> lhs, TrajectoryID_<T> rhs)
+{
+  return lhs.value() < rhs.value();
+}
+
+template<typename T>
+inline std::ostream& operator<<(std::ostream& os, TrajectoryID_<T> id)
+{
+  os << "ID" << id.value();
+  return os;
+}
+
+typedef TrajectoryID_<uint64_t> TrajectoryID;
+
+} // end namespace descartes_core
+
+
+#endif

--- a/descartes_core/include/descartes_core/trajectory_id.h
+++ b/descartes_core/include/descartes_core/trajectory_id.h
@@ -7,9 +7,25 @@
 namespace descartes_core
 {
 
+namespace detail
+{
+
+/**
+ * @brief Unimplemented base for IdGenerator. Users should specialize
+ *        this struct for the base ID type. It represents a concept 
+ *        that defines the following types:
+ *        1. value_type typedef representing the type of unique state object
+ *        2. value_type make_nil() function that returns a nil sentinel state object
+ *        3. value_type make_id() function that returns a unique state object
+ *        4. bool is_nil(value_type) function that tests if an object is the sentinel
+ */
 template<typename T>
 struct IdGenerator;
 
+/**
+ * @brief This specialization of the id generator uses a 64 bit unsigned integer
+ *        for the unique 'state'. Zero is reserved as a special value
+ */
 template<>
 struct IdGenerator<uint64_t>
 {
@@ -31,34 +47,61 @@ struct IdGenerator<uint64_t>
   }
 
 private:
+  // Initialized to 1
   static boost::atomic<value_type> counter_;
 };
 
+}
+
+/**
+ * @brief TrajectoryID_ represents a unique id to be associated with a TrajectoryPt
+ *
+ */
 template<typename T>
 class TrajectoryID_
 {
 public:
   typedef T value_type;
 
+  /**
+   * @brief Constructor for generating a trajectory id using the given state object 
+   */
   TrajectoryID_(value_type id)
     : id_(id)
   {}
 
+  /**
+   * @brief Constructor for generating a trajectory with a default id. Here we default
+   *        the points to nil. Default constructor is needed for STL containers.
+   */
   TrajectoryID_()
+    : id_(detail::IdGenerator<value_type>::make_nil())
   {}
 
-  bool is_nil() const { return IdGenerator<value_type>::is_nil(id_); }
+  /**
+   * @brief Tests if this ID is nil
+   */
+  bool is_nil() const { return detail::IdGenerator<value_type>::is_nil(id_); }
 
+  /**
+   * @brief Retrieves the value of the underlying id state object
+   */
   value_type value() const { return id_; }
 
+  /**
+   * @brief Factory function to generate a trajectory ID with a unique state object
+   */
   static TrajectoryID_<value_type> make_id()
   {
-    return TrajectoryID_<value_type>( IdGenerator<value_type>::make_id() );
+    return TrajectoryID_<value_type>( detail::IdGenerator<value_type>::make_id() );
   }
 
+  /**
+   * @brief Factory function to generate a trajectory ID with a nil state object
+   */
   static TrajectoryID_<value_type> make_nil()
   {
-    return TrajectoryID_<value_type>( IdGenerator<value_type>::make_nil() );
+    return TrajectoryID_<value_type>( detail::IdGenerator<value_type>::make_nil() );
   }
 
 private:

--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -33,6 +33,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include "descartes_core/robot_model.h"
 #include "descartes_core/trajectory_pt_transition.h"
+#include "descartes_core/trajectory_id.h"
 
 
 namespace descartes_core
@@ -71,8 +72,8 @@ DESCARTES_CLASS_FORWARD(TrajectoryPt);
 class TrajectoryPt
 {
 public:
-  typedef boost::uuids::uuid ID;
-  TrajectoryPt() : id_(boost::uuids::random_generator()()) {}
+  typedef TrajectoryID ID;
+  TrajectoryPt() : id_(TrajectoryID::make_id()) {}
   virtual ~TrajectoryPt() {}
 
   /**@name Getters for Cartesian pose(s)
@@ -176,7 +177,7 @@ public:
   virtual void cloneTo(TrajectoryPt &clone) const
   {
     clone = *this;
-    clone.setID(boost::uuids::random_generator()());
+    clone.setID(TrajectoryID::make_id());
   }
 
 

--- a/descartes_core/src/trajectory_id.cpp
+++ b/descartes_core/src/trajectory_id.cpp
@@ -1,5 +1,5 @@
 #include "descartes_core/trajectory_id.h"
 
 using namespace descartes_core;
-boost::atomic<uint64_t> IdGenerator<uint64_t>::counter_ (1);
+boost::atomic<uint64_t> detail::IdGenerator<uint64_t>::counter_ (1);
 

--- a/descartes_core/src/trajectory_id.cpp
+++ b/descartes_core/src/trajectory_id.cpp
@@ -1,0 +1,5 @@
+#include "descartes_core/trajectory_id.h"
+
+using namespace descartes_core;
+boost::atomic<uint64_t> IdGenerator<uint64_t>::counter_ (1);
+

--- a/descartes_planner/src/dense_planner.cpp
+++ b/descartes_planner/src/dense_planner.cpp
@@ -62,7 +62,7 @@ descartes_core::TrajectoryPt::ID DensePlanner::getPrevious(const descartes_core:
   auto pos = std::find_if(path_.begin()++,path_.end(),predicate);
   if(pos == path_.end() )
   {
-    id =  boost::uuids::nil_uuid();
+    id =  descartes_core::TrajectoryID::make_nil();
   }
   else
   {
@@ -77,11 +77,11 @@ bool DensePlanner::updatePath()
 {
   std::vector<descartes_core::TrajectoryPtPtr> traj;
   const CartesianMap& cart_map = planning_graph_->getCartesianMap();
-  descartes_core::TrajectoryPt::ID first_id = boost::uuids::nil_uuid();
+  descartes_core::TrajectoryPt::ID first_id = descartes_core::TrajectoryID::make_nil();
   auto predicate = [&first_id](const std::pair<descartes_core::TrajectoryPt::ID,CartesianPointInformation>& p)
     {
       const auto& info = p.second;
-      if(info.links_.id_previous == boost::uuids::nil_uuid())
+      if(info.links_.id_previous == descartes_core::TrajectoryID::make_nil())
       {
         first_id = p.first;
         return true;
@@ -95,7 +95,7 @@ bool DensePlanner::updatePath()
   // finding first point
   if(cart_map.empty()
       || (std::find_if(cart_map.begin(),cart_map.end(),predicate) == cart_map.end())
-      || first_id == boost::uuids::nil_uuid())
+      || first_id == descartes_core::TrajectoryID::make_nil())
   {
     error_code_ = descartes_core::PlannerError::INVALID_ID;
     return false;
@@ -159,7 +159,7 @@ descartes_core::TrajectoryPt::ID DensePlanner::getNext(const descartes_core::Tra
   auto pos = std::find_if(path_.begin(),path_.end()-2,predicate);
   if(pos == path_.end() )
   {
-    id =  boost::uuids::nil_uuid();
+    id =  descartes_core::TrajectoryID::make_nil();
   }
   else
   {

--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -56,7 +56,7 @@ PlanningGraph::~PlanningGraph()
 
 CartesianMap PlanningGraph::getCartesianMap()
 {
-  TrajectoryPt::ID cart_id = generate_nil();
+  TrajectoryPt::ID cart_id = descartes_core::TrajectoryID::make_nil();
   for(std::map<TrajectoryPt::ID, CartesianPointInformation>::iterator c_iter = cartesian_point_link_->begin();
       c_iter != cartesian_point_link_->end(); c_iter++)
   {
@@ -107,7 +107,7 @@ bool PlanningGraph::insertGraph(const std::vector<TrajectoryPtPtr> *points)
 
   // DEBUG
   //printMaps();
-  TrajectoryPt::ID previous_id = boost::uuids::nil_uuid();
+  TrajectoryPt::ID previous_id = descartes_core::TrajectoryID::make_nil();
 
   // input is valid, copy to local maps that will be maintained by the planning graph
   for (std::vector<TrajectoryPtPtr>::const_iterator point_iter = points->begin();
@@ -116,8 +116,8 @@ bool PlanningGraph::insertGraph(const std::vector<TrajectoryPtPtr> *points)
     (*cartesian_point_link_)[point_iter->get()->getID()].source_trajectory_ = (*point_iter);
     CartesianPointRelationship point_link = CartesianPointRelationship();
     point_link.id = point_iter->get()->getID();
-    point_link.id_next = generate_nil(); // default to nil UUID
-    point_link.id_previous = generate_nil(); // default to nil UUID
+    point_link.id_next = descartes_core::TrajectoryID::make_nil(); // default to nil UUID
+    point_link.id_previous = descartes_core::TrajectoryID::make_nil(); // default to nil UUID
 
     // if the previous_id exists, set it's next_id to the new id
     if (cartesian_point_link_->find(previous_id) != cartesian_point_link_->end())

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -214,7 +214,7 @@ bool SparsePlanner::addBefore(const TrajectoryPt::ID& ref_id,TrajectoryPtPtr cp)
     return false;
   }
 
-  prev_id = (sparse_index == 0) ? boost::uuids::nil_uuid() : std::get<1>(sparse_solution_array_[sparse_index - 1])->getID();
+  prev_id = (sparse_index == 0) ? descartes_core::TrajectoryID::make_nil() : std::get<1>(sparse_solution_array_[sparse_index - 1])->getID();
   next_id = std::get<1>(sparse_solution_array_[sparse_index])->getID();
 
   // inserting into dense array
@@ -459,11 +459,11 @@ bool SparsePlanner::getSparseSolutionArray(SolutionArray& sparse_solution_array)
 bool SparsePlanner::getOrderedSparseArray(std::vector<TrajectoryPtPtr>& sparse_array)
 {
   const CartesianMap& cart_map = planning_graph_->getCartesianMap();
-  TrajectoryPt::ID first_id = boost::uuids::nil_uuid();
+  TrajectoryPt::ID first_id = descartes_core::TrajectoryID::make_nil();
   auto predicate = [&first_id](const std::pair<TrajectoryPt::ID,CartesianPointInformation>& p)
     {
       const auto& info = p.second;
-      if(info.links_.id_previous == boost::uuids::nil_uuid())
+      if(info.links_.id_previous == descartes_core::TrajectoryID::make_nil())
       {
         first_id = p.first;
         return true;
@@ -477,7 +477,7 @@ bool SparsePlanner::getOrderedSparseArray(std::vector<TrajectoryPtPtr>& sparse_a
   // finding first point
   if(cart_map.empty()
       || (std::find_if(cart_map.begin(),cart_map.end(),predicate) == cart_map.end())
-      || first_id == boost::uuids::nil_uuid())
+      || first_id == descartes_core::TrajectoryID::make_nil())
   {
     return false;
   }
@@ -623,7 +623,7 @@ bool SparsePlanner::plan()
 
           if(sparse_index == 0)
           {
-            prev_id = boost::uuids::nil_uuid();
+            prev_id = descartes_core::TrajectoryID::make_nil();
             next_id = std::get<1>(sparse_solution_array_[sparse_index])->getID();
           }
           else

--- a/descartes_trajectory/test/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/test/cart_trajectory_pt.cpp
@@ -167,12 +167,3 @@ TEST(CartTrajPt, closestJointPose)
   ROS_INFO_STREAM("Testing equality between seed joint pose and closest joint pose");
   EXPECT_EQ(joint_pose,closest_joint_pose);
 }
-
-TEST(CartTrajPt, generationTimeTest)
-{
-  for (size_t i = 0; i < 100; i++)
-  {
-    CartTrajectoryPt pt;
-    ROS_INFO_STREAM(pt.getID());
-  }
-}

--- a/descartes_trajectory/test/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/test/cart_trajectory_pt.cpp
@@ -167,3 +167,12 @@ TEST(CartTrajPt, closestJointPose)
   ROS_INFO_STREAM("Testing equality between seed joint pose and closest joint pose");
   EXPECT_EQ(joint_pose,closest_joint_pose);
 }
+
+TEST(CartTrajPt, generationTimeTest)
+{
+  for (size_t i = 0; i < 100; i++)
+  {
+    CartTrajectoryPt pt;
+    ROS_INFO_STREAM(pt.getID());
+  }
+}


### PR DESCRIPTION
This PR creates a trajectory ID class that encapsulates a unique state object. I tried to design the implementation so it will be easy to switch the underlying state object to any type we want (including UUIDs). 

The current system works by keeping an atomic integer and incrementing it every time we generate a new point. This is very fast compared to making UUIDs and we save something like 90% of the time previously required. It has limitations though:
1. We can only generate 2^64 - 1 unique IDs in a single process. 
2. IDs are only unique to a given process.

There might be more limitations and I invite conversation on what the right answer is. I find the performance improvement compelling and was my primary motivation for doing this. Trajectories of several hundred points solve more or less instantly for me now.
