### PR TITLE
Issue #99 - Replace Atomics with Mutex

### DIFF
--- a/descartes_core/include/descartes_core/trajectory_id.h
+++ b/descartes_core/include/descartes_core/trajectory_id.h
@@ -1,8 +1,9 @@
 #ifndef TRAJECTORY_ID_H
 #define TRAJECTORY_ID_H
 
-#include <boost/atomic.hpp>
 #include <iostream>
+
+#include <boost/thread/mutex.hpp>
 
 namespace descartes_core
 {
@@ -38,6 +39,7 @@ struct IdGenerator<uint64_t>
 
   static value_type make_id()
   {
+    boost::unique_lock<boost::mutex> scoped_lock (counter_mutex_);
     return counter_++;
   }
 
@@ -48,7 +50,8 @@ struct IdGenerator<uint64_t>
 
 private:
   // Initialized to 1
-  static boost::atomic<value_type> counter_;
+  static value_type counter_;
+  static boost::mutex counter_mutex_;
 };
 
 }

--- a/descartes_core/src/trajectory_id.cpp
+++ b/descartes_core/src/trajectory_id.cpp
@@ -1,5 +1,6 @@
 #include "descartes_core/trajectory_id.h"
 
 using namespace descartes_core;
-boost::atomic<uint64_t> detail::IdGenerator<uint64_t>::counter_ (1);
+uint64_t detail::IdGenerator<uint64_t>::counter_ (1);
+boost::mutex detail::IdGenerator<uint64_t>::counter_mutex_;
 


### PR DESCRIPTION
This PR replaces the usage of atomics in the UUID replacement pull request with mutexes. Unfortunately, easy to use atomic headers are not available in gcc 4.6 or Boost 1.46 which are shipped with 12.04 / Hydro. This does away with them entirely and just adds a lock. 
