### PR TITLE
Doxygen Mainpage Updates

### DIFF
--- a/descartes_trajectory/mainpage.dox
+++ b/descartes_trajectory/mainpage.dox
@@ -13,5 +13,6 @@ Provide an overview of your package.
 The reference implementations are:
 - descartes_trajectory::CartTrajectoryPt : A trajectory point representing a 6D cartesian pose, possibly with some tolerances. Points in cartesian space are sampled and then expanded into (possibly many) joint solutions using descartes_core::RobotModel.
 - descartes_trajectory::JointTrajectoryPt : A trajectory point representing the specification of the position of all active joints on the robot, optionally with tolerances. 
+- descartes_trajectory::AxialSymmetricPt : A specialization of descartes_trajectory::CartTrajectoryPt where all tolerances are zero except for a given rotation axis which is allowed to rotate freely. A user may specify a nominal pose for the end-effector and an axis (X_AXIS, Y_AXIS, or Z_AXIS) representing the axis of the nominal pose about which to search for solutions.
 
 */


### PR DESCRIPTION
This PR updates the mainpage.dox of descartes_trajectory to include the axially symmetric point class.
