### PR TITLE
Issue #103 - polymorphic clone and copy

### DIFF
--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -171,15 +171,22 @@ public:
   }
   /** @} (end section) */
 
-  /**@brief Clones a trajectory point.  Performs a copy operation and then creates a new ID
-   * @param clone A copy of this trajectory point with a different ID
+  /**
+   * @brief Makes a copy of the underlying trajectory point and returns a polymorphic handle to it
+   * @return A copy, with the same ID, of the underlying point type
    */
-  virtual void cloneTo(TrajectoryPt &clone) const
-  {
-    clone = *this;
-    clone.setID(TrajectoryID::make_id());
-  }
+  virtual TrajectoryPtPtr copy() const = 0;
 
+  /**
+   * @brief Makes a clone of the underlying trajectory point and returns a polymorphic handle to it
+   * @return A clone, with the same data but a unique ID, of the underlying point type
+   */
+  virtual TrajectoryPtPtr clone() const
+  {
+    TrajectoryPtPtr cp = copy();
+    cp->setID(TrajectoryID::make_id());
+    return cp;
+  }
 
 protected:
   ID                            id_;                    /**<@brief ID associated with this pt. Generally refers back to a process path defined elsewhere. */

--- a/descartes_trajectory/include/descartes_trajectory/axial_symmetric_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/axial_symmetric_pt.h
@@ -73,6 +73,11 @@ public:
    */
   AxialSymmetricPt(const Eigen::Affine3d& pose, double orient_increment, FreeAxis axis);
 
+  virtual descartes_core::TrajectoryPtPtr copy() const
+  {
+    return descartes_core::TrajectoryPtPtr(new AxialSymmetricPt(*this));
+  }
+
 };
 
 

--- a/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
@@ -288,6 +288,11 @@ public:
    */
   virtual bool setDiscretization(const std::vector<double> &discretization);
 
+  virtual descartes_core::TrajectoryPtPtr copy() const
+  {
+    return descartes_core::TrajectoryPtPtr(new CartTrajectoryPt(*this));
+  }
+
   inline
   void setTool(const descartes_core::Frame &base, const TolerancedFrame &pt)
   {

--- a/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
@@ -161,6 +161,11 @@ public:
    */
   virtual bool setDiscretization(const std::vector<double> &discretization);
 
+  virtual descartes_core::TrajectoryPtPtr copy() const
+  {
+    return descartes_core::TrajectoryPtPtr(new JointTrajectoryPt(*this));
+  }
+
 inline
   void setJoints(const std::vector<TolerancedJointValue> &joints)
   {

--- a/descartes_trajectory/test/trajectory_pt.cpp
+++ b/descartes_trajectory/test/trajectory_pt.cpp
@@ -52,27 +52,22 @@ template <class T>
 class TrajectoryPtTest : public testing::Test {
  protected:
 
-  TrajectoryPtTest() : lhs_(CreateTrajectoryPt<T>()), rhs_(CreateTrajectoryPt<T>()),
-    lhs_copy_(CreateTrajectoryPt<T>()), lhs_clone_(CreateTrajectoryPt<T>())
+  TrajectoryPtTest() 
+    : lhs_(CreateTrajectoryPt<T>()) 
+    , rhs_(CreateTrajectoryPt<T>())
+    , lhs_copy_(CreateTrajectoryPt<T>())
+    , lhs_clone_(CreateTrajectoryPt<T>())
   {
-    *lhs_copy_ = *lhs_;
-    lhs_->cloneTo(*lhs_clone_);
+    lhs_copy_ = lhs_->copy();
+    lhs_clone_ = lhs_->clone();
     lhs_same_ = lhs_;
   }
 
-  virtual ~TrajectoryPtTest()
-  {
-    delete lhs_;
-    delete rhs_;
-    delete lhs_copy_;
-    delete lhs_clone_;
-  }
-
-  TrajectoryPt* lhs_;
-  TrajectoryPt* rhs_;
-  TrajectoryPt* lhs_copy_;
-  TrajectoryPt* lhs_clone_;
-  TrajectoryPt* lhs_same_;
+  TrajectoryPtPtr lhs_;
+  TrajectoryPtPtr rhs_;
+  TrajectoryPtPtr lhs_copy_;
+  TrajectoryPtPtr lhs_clone_;
+  TrajectoryPtPtr lhs_same_;
 };
 
 using testing::Types;


### PR DESCRIPTION
Issue #103: This PR changes the trajectory point base class to have a pure virtual function copy() that returns a shared pointer to a trajectory point. It re-factors the clone() method to use this copy routine. 

Tests have been similarly updated. This PR introduces the requirement that all derivatives of trajectory pt must implement a copy function.
