### PR TITLE
issue #114 AxialSymetricPt initialization

### DIFF
--- a/descartes_trajectory/src/axial_symmetric_pt.cpp
+++ b/descartes_trajectory/src/axial_symmetric_pt.cpp
@@ -5,18 +5,46 @@ using descartes_trajectory::TolerancedFrame;
 using descartes_trajectory::AxialSymmetricPt;
 using namespace descartes_core::utils;
 
-static TolerancedFrame makeRotationalAxis(AxialSymmetricPt::FreeAxis axis)
+static TolerancedFrame makeUnconstrainedRotation(double x, double y, double z, double rx, double ry, double rz,
+                                          AxialSymmetricPt::FreeAxis axis)
 {
   using namespace descartes_trajectory;
 
-  Eigen::Affine3d rot = Eigen::Affine3d::Identity();
-  PositionTolerance pos_tol = ToleranceBase::zeroTolerance<PositionTolerance>(0,0,0);
-  OrientationTolerance orient_tol = ToleranceBase::createSymmetric<OrientationTolerance>(0.0, 0.0, 0.0, 
-                                    ((axis == AxialSymmetricPt::X_AXIS) ? 2*M_PI : 0.0),
-                                    ((axis == AxialSymmetricPt::Y_AXIS) ? 2*M_PI : 0.0),
-                                    ((axis == AxialSymmetricPt::Z_AXIS) ? 2*M_PI : 0.0));
-  return TolerancedFrame(rot, pos_tol, orient_tol);
-} 
+  Eigen::Affine3d pose = toFrame(x, y, z, rx, ry, rz, EulerConventions::XYZ);
+  PositionTolerance pos_tol = ToleranceBase::zeroTolerance<PositionTolerance>(x,y,z);
+  OrientationTolerance orient_tol = ToleranceBase::createSymmetric<OrientationTolerance>(
+      ((axis == AxialSymmetricPt::X_AXIS) ? 0.0 : rx),
+      ((axis == AxialSymmetricPt::Y_AXIS) ? 0.0 : ry),
+      ((axis == AxialSymmetricPt::Z_AXIS) ? 0.0 : rz),
+      ((axis == AxialSymmetricPt::X_AXIS) ? 2*M_PI : 0.0),
+      ((axis == AxialSymmetricPt::Y_AXIS) ? 2*M_PI : 0.0),
+      ((axis == AxialSymmetricPt::Z_AXIS) ? 2*M_PI : 0.0));
+  return TolerancedFrame(pose, pos_tol, orient_tol);
+}
+
+static TolerancedFrame makeUnconstrainedRotation(const Eigen::Affine3d& pose,
+                                          AxialSymmetricPt::FreeAxis axis)
+{
+  using namespace descartes_trajectory;
+
+  Eigen::Vector3d rpy = pose.rotation().eulerAngles(0,1,2);
+  double rx = rpy(0);
+  double ry = rpy(1);
+  double rz = rpy(2);
+  double x = pose.translation()(0);
+  double y = pose.translation()(1);
+  double z = pose.translation()(2);
+
+  PositionTolerance pos_tol = ToleranceBase::zeroTolerance<PositionTolerance>(x,y,z);
+  OrientationTolerance orient_tol = ToleranceBase::createSymmetric<OrientationTolerance>(
+      ((axis == AxialSymmetricPt::X_AXIS) ? 0.0 : rx),
+      ((axis == AxialSymmetricPt::Y_AXIS) ? 0.0 : ry),
+      ((axis == AxialSymmetricPt::Z_AXIS) ? 0.0 : rz),
+      ((axis == AxialSymmetricPt::X_AXIS) ? 2*M_PI : 0.0),
+      ((axis == AxialSymmetricPt::Y_AXIS) ? 2*M_PI : 0.0),
+      ((axis == AxialSymmetricPt::Z_AXIS) ? 2*M_PI : 0.0));
+  return TolerancedFrame(pose, pos_tol, orient_tol);
+}
 
 
 namespace descartes_trajectory
@@ -24,20 +52,14 @@ namespace descartes_trajectory
 
 AxialSymmetricPt::AxialSymmetricPt(double x, double y, double z, double rx, double ry, double rz,
                                    double orient_increment, FreeAxis axis) :
-  CartTrajectoryPt(toFrame(x, y, z, rx, ry, rz, EulerConventions::XYZ),
-                   makeRotationalAxis(axis),
-                   Eigen::Affine3d::Identity(),
-                   Eigen::Affine3d::Identity(),
+  CartTrajectoryPt(makeUnconstrainedRotation(x, y, z, rx, ry, rz,axis),
                    0.0, // The position discretization
                    orient_increment) // Orientation discretization (starting at -2Pi and marching to 2Pi)
 {
 }
 
 AxialSymmetricPt::AxialSymmetricPt(const Eigen::Affine3d& pose, double orient_increment, FreeAxis axis) :
-  CartTrajectoryPt(pose,
-                   makeRotationalAxis(axis),
-                   Eigen::Affine3d::Identity(),
-                   Eigen::Affine3d::Identity(),
+  CartTrajectoryPt(makeUnconstrainedRotation(pose,axis),
                    0.0, // The position discretization
                    orient_increment) // Orientation discretization (starting at -2Pi and marching to 2Pi)
 {


### PR DESCRIPTION
Related to issue #114.
This PR changes the AxialSymetricPt constructors so that they call the CartesianPt constructor that sets the nominal values of the tolerance frame. This allows for the translation and rotation bounds of the wobj_pt tolerance frame to be properly defined.  This change fixes the SparsePlanner which now gets valid joint poses whenever it calls the  **getClosestJointPose** method
