### PR TITLE
returns true when a solution is found

### DIFF
--- a/descartes_trajectory/src/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/src/cart_trajectory_pt.cpp
@@ -357,7 +357,7 @@ bool CartTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_state
         return false;
       }
 
-      return false;
+      return true;
     }
   }
   else


### PR DESCRIPTION
A "false" boolean was being returned by the the getClosestJointPose(...) method even though a solution was found.  This PR fixes this.
