### PR TITLE
Fix to Sparse Planner crash

### DIFF
--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -763,11 +763,12 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
           const JointTrajectoryPt& last_joint_pt = joint_points_map_.at(cart_points_[pos-1]->getID());
           std::vector<double> last_joint_pose;
           last_joint_pt.getNominalJointPose(std::vector<double>(), *robot_model, last_joint_pose);
-          // look up dt
-          double dt = timing_cache_[pos].upper;
-          // check validity of joint motion
 
-          if (dt > 0.0 && !robot_model->isValidMove(last_joint_pose, aprox_interp, dt))
+          // retreiving timing constraint
+          const descartes_core::TimingConstraint& tm = timing_cache_[pos];
+
+          // check validity of joint motion
+          if (tm.isSpecified() && !robot_model->isValidMove(last_joint_pose, aprox_interp, tm.upper))
           {
             ROS_WARN_STREAM("Joint velocity checking failed for point " << pos << ". Replanning.");
             sparse_index = k;

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -767,9 +767,11 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
           double dt = timing_cache_[pos].upper;
           // check validity of joint motion
 
-          if (!robot_model->isValidMove(last_joint_pose, aprox_interp, dt))
+          if (dt > 0.0 && !robot_model->isValidMove(last_joint_pose, aprox_interp, dt))
           {
             ROS_WARN_STREAM("Joint velocity checking failed for point " << pos << ". Replanning.");
+            sparse_index = k;
+            point_pos = pos;
             return static_cast<int>(InterpolationResult::REPLAN);
           }
 


### PR DESCRIPTION
After the introduction of the timing information in each trajectory point #65 the SparsePlanner crashes, possibly running into a segfault.  This error was encountered when planning for the robot setup in the [descartes_demo](https://github.com/jrgnicho/demo_descartes) package for which the SparsePlanner had previously worked.  This PR fixes this issue.
