### PR TITLE
JointTrajectoryPt isValid() Fix

### DIFF
--- a/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
@@ -31,43 +31,25 @@
 namespace descartes_trajectory
 {
 
-//TODO add warning if non-zero tolerances are specified because initial implementation will only allow fixed joints
-struct JointTolerance
-{
-  JointTolerance(): lower(0.), upper(0.) {};
-  JointTolerance(double low, double high):
-    lower(std::abs(low)), upper(std::abs(high)) {};
-
-  double lower, upper;
-};
-
+/**
+ * @brief Structure to specify a valid joint range [lower, upper] with a nominal position given by 'nominal'.
+ */
 struct TolerancedJointValue
 {
-  TolerancedJointValue() {};
-  TolerancedJointValue(double _nominal, double _tol_above, double _tol_below):
-    nominal(_nominal), tolerance(_tol_above, _tol_below) {};
-  TolerancedJointValue(double _nominal)
-  {
-    *this = TolerancedJointValue(_nominal, 0., 0.);
-  }
+  TolerancedJointValue(double nominal, double lower, double upper)
+    : nominal(nominal), lower(lower), upper(upper)
+  {}
 
-  double upperBound() const
-  {
-    return nominal+tolerance.upper;
-  }
-
-  double lowerBound() const
-  {
-    return nominal-tolerance.lower;
-  }
+  TolerancedJointValue(double nominal)
+    : nominal(nominal), lower(nominal), upper(nominal)
+  {}
 
   double range() const
   {
-    return upperBound() - lowerBound();
+    return upper - lower;
   }
 
-  double nominal;
-  JointTolerance tolerance;
+  double nominal, lower, upper;
 };
 
 /**@brief Joint Trajectory Point used to describe a joint goal for a robot trajectory.
@@ -170,11 +152,7 @@ public:
     return descartes_core::TrajectoryPtPtr(new JointTrajectoryPt(*this));
   }
 
-inline
-  void setJoints(const std::vector<TolerancedJointValue> &joints)
-  {
-    joint_position_ = joints;
-  }
+  void setJoints(const std::vector<TolerancedJointValue> &joints);
 
   inline
   void setTool(const descartes_core::Frame &tool)
@@ -188,9 +166,30 @@ inline
     wobj_ = wobj;
   }
   /**@} (end Setters section) */
+
+  inline
+  const std::vector<double>& nominal() const
+  {
+    return nominal_;
+  }
+
+  inline
+  const std::vector<double>& upper() const
+  {
+    return upper_;
+  }
+
+  inline
+  const std::vector<double>& lower() const
+  {
+    return lower_;
+  }
+
 protected:
-  std::vector<TolerancedJointValue> joint_position_;  /**<@brief Fixed joint position with tolerance */
-  std::vector<double>               discretization_;  /**<@brief How finely to discretize each joint */
+  std::vector<double> nominal_;
+  std::vector<double> lower_;
+  std::vector<double> upper_;
+  std::vector<double> discretization_;  /**<@brief How finely to discretize each joint */
 
   /** @name JointTrajectoryPt transforms. Used in get*CartPose() methods and for interpolation.
    *  @{

--- a/descartes_trajectory/src/joint_trajectory_pt.cpp
+++ b/descartes_trajectory/src/joint_trajectory_pt.cpp
@@ -27,6 +27,26 @@
 
 #define NOT_IMPLEMENTED_ERR(ret) logError("%s not implemented", __PRETTY_FUNCTION__); return ret;
 
+// Utility function to unpack joint bounds from a TolerancedJointValue struct
+// Note that this does not clear the existing vectors.
+static void unpackTolerancedJoints(const std::vector<descartes_trajectory::TolerancedJointValue>& tolerances,
+                                   std::vector<double>& lower,
+                                   std::vector<double>& nominal,
+                                   std::vector<double>& upper)
+{
+  lower.reserve(tolerances.size());
+  nominal.reserve(tolerances.size());
+  upper.reserve(tolerances.size());
+  
+  for (std::size_t i = 0; i < tolerances.size(); ++i)
+  {
+    lower.push_back(tolerances[i].lower);
+    nominal.push_back(tolerances[i].nominal);
+    upper.push_back(tolerances[i].upper);
+  }
+}
+
+
 using namespace descartes_core;
 namespace descartes_trajectory
 {
@@ -40,31 +60,31 @@ JointTrajectoryPt::JointTrajectoryPt(const descartes_core::TimingConstraint& tim
 JointTrajectoryPt::JointTrajectoryPt(const std::vector<TolerancedJointValue> &joints,
                                      const Frame &tool, const Frame &wobj,
                                      const descartes_core::TimingConstraint& timing)
-  : descartes_core::TrajectoryPt(timing),
-  joint_position_(joints),
-  tool_(tool),
-  wobj_(wobj)
-{}
+  : descartes_core::TrajectoryPt(timing)
+  , tool_(tool)
+  , wobj_(wobj)
+{
+  unpackTolerancedJoints(joints, lower_, nominal_, upper_);
+}
 
 JointTrajectoryPt::JointTrajectoryPt(const std::vector<TolerancedJointValue> &joints, 
                                      const descartes_core::TimingConstraint& timing)
-  : descartes_core::TrajectoryPt(timing),
-  joint_position_(joints),
-  tool_(Eigen::Affine3d::Identity()),
-  wobj_(Eigen::Affine3d::Identity())
-{}
+  : descartes_core::TrajectoryPt(timing)
+  , tool_(Eigen::Affine3d::Identity())
+  , wobj_(Eigen::Affine3d::Identity())
+{
+  unpackTolerancedJoints(joints, lower_, nominal_, upper_);
+}
 
 JointTrajectoryPt::JointTrajectoryPt(const std::vector<double> &joints,
                                      const descartes_core::TimingConstraint& timing)
-  : descartes_core::TrajectoryPt(timing),
-  tool_(Eigen::Affine3d::Identity()),
-  wobj_(Eigen::Affine3d::Identity())
-{
-  for (size_t ii = 0; ii < joints.size(); ++ii)
-  {
-    joint_position_.push_back(TolerancedJointValue(joints[ii]));
-  }
-}
+  : nominal_(joints)
+  , lower_(joints)
+  , upper_(joints)
+  , descartes_core::TrajectoryPt(timing)
+  , tool_(Eigen::Affine3d::Identity())
+  , wobj_(Eigen::Affine3d::Identity())
+{}
 
 
 bool JointTrajectoryPt::getClosestCartPose(const std::vector<double> &seed_state,
@@ -76,12 +96,7 @@ bool JointTrajectoryPt::getClosestCartPose(const std::vector<double> &seed_state
 bool JointTrajectoryPt::getNominalCartPose(const std::vector<double> &seed_state,
                                            const RobotModel &model, Eigen::Affine3d &pose) const
 {
-  std::vector<double> joints;
-  for(auto& tj: joint_position_)
-  {
-    joints.push_back(tj.nominal);
-  }
-  return model.getFK(joints,pose);
+  return model.getFK(nominal_, pose);
 }
 
 void JointTrajectoryPt::getCartesianPoses(const RobotModel &model, EigenSTL::vector_Affine3d &poses) const
@@ -93,7 +108,7 @@ bool JointTrajectoryPt::getClosestJointPose(const std::vector<double> &seed_stat
                                             const RobotModel &model,
                                             std::vector<double> &joint_pose) const
 {
-  if(joint_position_.empty())
+  if(nominal_.empty())
   {
     return false;
   }
@@ -107,11 +122,7 @@ bool JointTrajectoryPt::getNominalJointPose(const std::vector<double> &seed_stat
                                             const RobotModel &model,
                                             std::vector<double> &joint_pose) const
 {
-  joint_pose.resize(joint_position_.size());
-  for (size_t ii=0; ii<joint_position_.size(); ++ii)
-  {
-    joint_pose[ii] = joint_position_[ii].nominal;
-  }
+  joint_pose.assign(nominal_.begin(), nominal_.end());
   return true;
 }
 
@@ -125,19 +136,12 @@ void JointTrajectoryPt::getJointPoses(const RobotModel &model,
 
 bool JointTrajectoryPt::isValid(const RobotModel &model) const
 {
-  std::vector<double> lower(joint_position_.size());
-  std::vector<double> upper(joint_position_.size());
-  for (size_t ii = 0; ii < joint_position_.size(); ++ii)
-  {
-    lower[ii] = joint_position_[ii].nominal + joint_position_[ii].tolerance.lower;
-    upper[ii] =  joint_position_[ii].nominal + joint_position_[ii].tolerance.upper;
-  }
-return model.isValid(lower) && model.isValid(upper);
+  return model.isValid(lower_) && model.isValid(upper_);
 }
 
 bool JointTrajectoryPt::setDiscretization(const std::vector<double> &discretization)
 {
-  if (discretization.size() != 1 || discretization.size() != joint_position_.size())
+  if (discretization.size() != 1 || discretization.size() != nominal_.size())
   {
     logError("discretization must be size 1 or same size as joint count.");
     return false;
@@ -145,14 +149,14 @@ bool JointTrajectoryPt::setDiscretization(const std::vector<double> &discretizat
 
   if (discretization.size() == 1)
   {
-    discretization_ = std::vector<double>(joint_position_.size(), discretization[0]);
+    discretization_ = std::vector<double>(nominal_.size(), discretization[0]);
     return true;
   }
 
   /* Do not copy discretization values until all values are confirmed */
   for (size_t ii=0; ii<discretization.size(); ++ii)
   {
-    if (discretization[ii] < 0. || discretization[ii] > joint_position_[ii].range())
+    if (discretization[ii] < 0. || discretization[ii] > (upper_[ii] - lower_[ii]))
     {
       logError("discretization value out of range.");
       return false;
@@ -162,6 +166,12 @@ bool JointTrajectoryPt::setDiscretization(const std::vector<double> &discretizat
   discretization_ = discretization;
 
   return true;
+}
+
+void JointTrajectoryPt::setJoints(const std::vector<TolerancedJointValue> &joints)
+{
+  lower_.clear(); nominal_.clear(); upper_.clear();
+  unpackTolerancedJoints(joints, lower_, nominal_, upper_);
 }
 
 } /* namespace descartes_trajectory */

--- a/descartes_trajectory/src/joint_trajectory_pt.cpp
+++ b/descartes_trajectory/src/joint_trajectory_pt.cpp
@@ -129,8 +129,8 @@ bool JointTrajectoryPt::isValid(const RobotModel &model) const
   std::vector<double> upper(joint_position_.size());
   for (size_t ii = 0; ii < joint_position_.size(); ++ii)
   {
-    lower[ii] = joint_position_[ii].tolerance.lower;
-    upper[ii] = joint_position_[ii].tolerance.upper;
+    lower[ii] = joint_position_[ii].nominal + joint_position_[ii].tolerance.lower;
+    upper[ii] =  joint_position_[ii].nominal + joint_position_[ii].tolerance.upper;
   }
 return model.isValid(lower) && model.isValid(upper);
 }


### PR DESCRIPTION
This PR fixes a bug in Joint Trajectory Point's isValid() function that was causing it to check incorrect joint configurations. 

JointTrajectoryPt has, for every joint, a 'joint position' that consists of a nominal value and an upper and lower tolerance from that point. The latter are stored as displacements from the nominal, not as absolute positions themselves. The isValid function was treating them as absolute positions and thus was checking the wrong joint angles.
