### PR TITLE
Planner Base Returns Joint Trajectory Points

### DIFF
--- a/descartes_core/include/descartes_core/path_planner_base.h
+++ b/descartes_core/include/descartes_core/path_planner_base.h
@@ -8,7 +8,7 @@
 #ifndef DESCARTES_CORE_PATH_PLANNER_BASE_H_
 #define DESCARTES_CORE_PATH_PLANNER_BASE_H_
 
-#include <descartes_core/trajectory_pt.h>
+#include <descartes_trajectory/joint_trajectory_pt.h>
 #include <descartes_core/robot_model.h>
 #include <vector>
 
@@ -76,7 +76,7 @@ public:
    * @brief Returns the last robot path generated from the input trajectory
    * @param path Array that contains the points in the robot path
    */
-  virtual bool getPath(std::vector<TrajectoryPtPtr>& path) const = 0;
+  virtual bool getPath(std::vector<descartes_trajectory::JointTrajectoryPtPtr>& path) const = 0;
 
   /**
    * @brief Add a point to the current path after the point with 'ref_id'.

--- a/descartes_planner/include/descartes_planner/dense_planner.h
+++ b/descartes_planner/include/descartes_planner/dense_planner.h
@@ -25,7 +25,7 @@ public:
   virtual bool setConfig(const descartes_core::PlannerConfig& config);
   virtual void getConfig(descartes_core::PlannerConfig& config) const;
   virtual bool planPath(const std::vector<descartes_core::TrajectoryPtPtr>& traj);
-  virtual bool getPath(std::vector<descartes_core::TrajectoryPtPtr>& path) const;
+  virtual bool getPath(std::vector<descartes_trajectory::JointTrajectoryPtPtr>& path) const;
   virtual bool addAfter(const descartes_core::TrajectoryPt::ID& ref_id, descartes_core::TrajectoryPtPtr tp);
   virtual bool addBefore(const descartes_core::TrajectoryPt::ID& ref_id, descartes_core::TrajectoryPtPtr tp);
   virtual bool remove(const descartes_core::TrajectoryPt::ID& ref_id);
@@ -45,7 +45,7 @@ protected:
   boost::shared_ptr<descartes_planner::PlanningGraph> planning_graph_;
   int error_code_;
   descartes_core::PlannerConfig config_;
-  std::vector<descartes_core::TrajectoryPtPtr> path_;
+  std::vector<descartes_trajectory::JointTrajectoryPtPtr> path_;
   std::map<int,std::string> error_map_;
 
 };

--- a/descartes_planner/include/descartes_planner/sparse_planner.h
+++ b/descartes_planner/include/descartes_planner/sparse_planner.h
@@ -50,7 +50,7 @@ public:
   virtual bool addBefore(const descartes_core::TrajectoryPt::ID& ref_id,descartes_core::TrajectoryPtPtr cp);
   virtual bool modify(const descartes_core::TrajectoryPt::ID& ref_id,descartes_core::TrajectoryPtPtr cp);
   virtual bool remove(const descartes_core::TrajectoryPt::ID& ref_id);
-  virtual bool getPath(std::vector<descartes_core::TrajectoryPtPtr>& path) const;
+  virtual bool getPath(std::vector<descartes_trajectory::JointTrajectoryPtPtr>& path) const;
   virtual int getErrorCode() const;
   virtual bool getErrorMessage(int error_code, std::string& msg) const;
 

--- a/descartes_planner/src/dense_planner.cpp
+++ b/descartes_planner/src/dense_planner.cpp
@@ -130,7 +130,7 @@ bool DensePlanner::updatePath()
       path_.resize(list.size());
       for(auto p : list)
       {
-        path_[counter] = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(p));
+        path_[counter] = descartes_trajectory::JointTrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(p)); // descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(p));
         path_[counter]->setID(traj[counter]->getID());
         counter++;
       }
@@ -213,7 +213,7 @@ bool DensePlanner::planPath(const std::vector<descartes_core::TrajectoryPtPtr>& 
   return descartes_core::PlannerError::OK == error_code_;
 }
 
-bool DensePlanner::getPath(std::vector<descartes_core::TrajectoryPtPtr>& path) const
+bool DensePlanner::getPath(std::vector<descartes_trajectory::JointTrajectoryPtPtr>& path) const
 {
   if (path_.empty()) return false;
   

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -542,7 +542,7 @@ bool SparsePlanner::getSolutionJointPoint(const CartTrajectoryPt::ID& cart_id, J
   return true;
 }
 
-bool SparsePlanner::getPath(std::vector<TrajectoryPtPtr>& path) const
+bool SparsePlanner::getPath(std::vector<descartes_trajectory::JointTrajectoryPtPtr>& path) const
 {
   if(cart_points_.empty() || joint_points_map_.empty())
   {
@@ -554,7 +554,7 @@ bool SparsePlanner::getPath(std::vector<TrajectoryPtPtr>& path) const
   {
     TrajectoryPtPtr p = cart_points_[i];
     const JointTrajectoryPt& j = joint_points_map_.at(p->getID());
-    TrajectoryPtPtr new_pt = TrajectoryPtPtr(new JointTrajectoryPt(j));
+    descartes_trajectory::JointTrajectoryPtPtr new_pt = descartes_trajectory::JointTrajectoryPtPtr(new JointTrajectoryPt(j));
     new_pt->setTiming(timing_cache_[i]);
     path[i] = new_pt;
   }

--- a/descartes_planner/test/dense_planner.cpp
+++ b/descartes_planner/test/dense_planner.cpp
@@ -138,7 +138,7 @@ TEST(DensePlanner, planPath)
 
 TEST(DensePlanner, getPath)
 {
-  std::vector<descartes_core::TrajectoryPtPtr> path;
+  std::vector<descartes_trajectory::JointTrajectoryPtPtr> path;
   EXPECT_TRUE(Planner.getPath(path));
   EXPECT_TRUE(path.size() == NUM_DENSE_POINTS);
 }

--- a/descartes_planner/test/sparse_planner.cpp
+++ b/descartes_planner/test/sparse_planner.cpp
@@ -138,7 +138,7 @@ TEST(SparsePlanner, planPath)
 
 TEST(SparsePlanner, getPath)
 {
-  std::vector<descartes_core::TrajectoryPtPtr> path;
+  std::vector<descartes_trajectory::JointTrajectoryPtPtr> path;
   EXPECT_TRUE(Planner.getPath(path));
   EXPECT_TRUE(path.size() == NUM_DENSE_POINTS);
 }

--- a/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
@@ -64,6 +64,7 @@ struct TolerancedJointValue
  *
  * The get*Pose() methods of JointTrajectoryPt try to set joint positions of a robot such that @e tool_ is coincident with @e wobj_.
  */
+DESCARTES_CLASS_FORWARD(JointTrajectoryPt);
 class JointTrajectoryPt: public descartes_core::TrajectoryPt
 {
 public:


### PR DESCRIPTION
This PR modifies the planner base's `getPath` function to return a 

``` c++
std::vector<descartes_trajectory::JointTrajectoryPtPtr>
```

instead of generic trajectory points. This improves usability because it allows users to use more specific functions that are not part of the interface of TrajectoryPt, like `nominal()`. On the downside, this is a **breaking** change. All code that used either of our planner implementations will have to be updated.

I believe this is a great step toward making descartes a nicer developer experience. I welcome feedback.
