### PR TITLE
Travis CI Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci_config"]
+	path = .ci_config
+	url = https://github.com/ros-industrial/industrial_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_failure: always
+
+env:
+  matrix:
+    - USE_DEB=true  
+      ROS_DISTRO="indigo" 
+      ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  
+      ROS_DISTRO="indigo" 
+      ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+
+script: 
+  - source .ci_config/travis.sh


### PR DESCRIPTION
Following the model of `industrial_core`, this PR adds the necessary submodule and configuration file to integrate with Travis CI. Appears to work on my own branch.

Please note that some of the tests will fail currently. This is because they expose existing bugs in the source code.
