### PR TITLE
Sparse Planner Refactoring (Issues 136-138)

### DIFF
--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -181,6 +181,19 @@ public:
   virtual TrajectoryPtPtr copy() const = 0;
 
   /**
+   * @brief Makes a copy of the underlying trajectory point, mutates the timing, and returns a
+   *        polymorphic handle to it.
+   * @param tm The new timing value for the copied point
+   * @return A copy, with the same ID and new timing, of the underlying point type
+   */
+  virtual TrajectoryPtPtr copyAndSetTiming(const TimingConstraint& tm) const
+  {
+    TrajectoryPtPtr cp = copy();
+    cp->setTiming(tm);
+    return cp;
+  }
+
+  /**
    * @brief Makes a clone of the underlying trajectory point and returns a polymorphic handle to it
    * @return A clone, with the same data but a unique ID, of the underlying point type
    */
@@ -188,6 +201,18 @@ public:
   {
     TrajectoryPtPtr cp = copy();
     cp->setID(TrajectoryID::make_id());
+    return cp;
+  }
+
+  /**
+   * @brief Makes a clone of the underlying trajectory point and returns a polymorphic handle to it with new timing
+   * @param tm The new timing value for the copied point
+   * @return A clone, with the same data but a unique ID, of the underlying point type with new timing
+   */
+  virtual TrajectoryPtPtr cloneAndSetTiming(const TimingConstraint& tm) const
+  {
+    TrajectoryPtPtr cp = clone();
+    cp->setTiming(tm);
     return cp;
   }
 

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -635,7 +635,7 @@ bool SparsePlanner::plan()
   // solving coarse trajectory
   bool replan = true;
   bool succeeded = false;
-  int max_replanning_attempts = cart_points_.size()/2;
+  int max_replanning_attempts = cart_points_.size();
   int replanning_attempts = 0;
   while(replan && getSparseSolutionArray(sparse_solution_array_))
   {

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -30,18 +30,39 @@ using namespace descartes_trajectory;
 
 namespace
 {
-    std::vector<descartes_core::TimingConstraint>
-    extractTiming(const std::vector<descartes_core::TrajectoryPtPtr>& points)
+  descartes_core::TimingConstraint
+  cumulativeTimingBetween(const std::vector<descartes_core::TrajectoryPtPtr>& dense_points,
+                          size_t start_index,
+                          size_t end_index)
+  {
+    descartes_core::TimingConstraint tm (0.0, 0.0);
+    for (size_t i = start_index + 1; i <= end_index; ++i)
     {
-      std::vector<descartes_core::TimingConstraint> result;
-      result.reserve(points.size());
-
-      for (const auto& ptr : points)
+      const descartes_core::TimingConstraint& pt_tm = dense_points[i]->getTiming();
+      if (pt_tm.isSpecified())
       {
-        result.push_back(ptr->getTiming());
+        // Add time as normal
+        tm.upper += pt_tm.upper;
+        tm.lower += pt_tm.lower;
       }
-      return result;
+      else
+      {
+        // A single unspecified timing makes the range unspecified
+        tm = descartes_core::TimingConstraint();
+        break;
+      }
     }
+    return tm;
+  }
+
+  descartes_core::TrajectoryPtPtr
+  copyAndSetTiming(const descartes_core::TrajectoryPtPtr& ptr, const descartes_core::TimingConstraint& tm)
+  {
+    descartes_core::TrajectoryPtPtr cloned = ptr->copy();
+    cloned->setTiming(tm);
+    return cloned;
+  }
+
 }
 
 
@@ -148,14 +169,6 @@ bool SparsePlanner::planPath(const std::vector<TrajectoryPtPtr>& traj)
   }
 
   ros::Time start_time = ros::Time::now();
-
-  // Save the timing information
-  timing_cache_ = extractTiming(traj);
-  // Unconstrain the times for the sparse sampling
-  for (std::size_t i = 0; i < traj.size(); ++i)
-  {
-    traj[i]->setTiming(descartes_core::TimingConstraint()); // default timing is (0,0)
-  }
 
   cart_points_.assign(traj.begin(),traj.end());
   std::vector<TrajectoryPtPtr> sparse_trajectory_array;
@@ -555,7 +568,6 @@ bool SparsePlanner::getPath(std::vector<TrajectoryPtPtr>& path) const
     TrajectoryPtPtr p = cart_points_[i];
     const JointTrajectoryPt& j = joint_points_map_.at(p->getID());
     TrajectoryPtPtr new_pt = TrajectoryPtPtr(new JointTrajectoryPt(j));
-    new_pt->setTiming(timing_cache_[i]);
     path[i] = new_pt;
   }
 
@@ -589,9 +601,26 @@ void SparsePlanner::sampleTrajectory(double sampling,const std::vector<Trajector
   int skip = std::ceil(double(1.0f)/sampling);
   ROS_INFO_STREAM("Sampling skip val: "<<skip<< " from sampling val: "<<sampling);
   ss<<"[";
-  for(int i = 0; i < dense_trajectory_array.size();i+=skip)
+  
+  if (dense_trajectory_array.empty()) return;
+
+  // Add the first point
+  sparse_trajectory_array.push_back(dense_trajectory_array.front());
+  ss << "0 ";
+  // The first point requires no special timing adjustment
+  
+  int i; // We keep i outside of the loop so we can examine it on the last step
+  for (i = skip; i < dense_trajectory_array.size(); i+=skip)
   {
-    sparse_trajectory_array.push_back(dense_trajectory_array[i]);
+    // Add the cumulative time of the dense trajectory back in
+    descartes_core::TimingConstraint tm = cumulativeTimingBetween(dense_trajectory_array,
+                                                                  i - skip,
+                                                                  i);
+    // We don't want to modify the input trajectory pointers, so we clone and modify them here
+    descartes_core::TrajectoryPtPtr cloned = copyAndSetTiming(dense_trajectory_array[i], tm);
+    // Write to the new array
+    sparse_trajectory_array.push_back(cloned);
+
     ss<<i<<" ";
   }
   ss<<"]";
@@ -600,7 +629,15 @@ void SparsePlanner::sampleTrajectory(double sampling,const std::vector<Trajector
   // add the last one
   if(sparse_trajectory_array.back()->getID() != dense_trajectory_array.back()->getID())
   {
-    sparse_trajectory_array.push_back(dense_trajectory_array.back());
+    // The final point is index size() - 1
+    // The point before is index ( i - skip )
+    descartes_core::TimingConstraint tm = cumulativeTimingBetween(dense_trajectory_array,
+                                                                  i - skip, 
+                                                                  dense_trajectory_array.size() - 1);
+    // We don't want to modify the input trajectory pointers, so we clone and modify them here
+    descartes_core::TrajectoryPtPtr cloned = copyAndSetTiming(dense_trajectory_array.back(), tm);
+    // Write to solution
+    sparse_trajectory_array.push_back(cloned);
   }
 }
 
@@ -638,8 +675,10 @@ bool SparsePlanner::plan()
   int replanning_attempts = 0;
   while(replan && getSparseSolutionArray(sparse_solution_array_))
   {
+    // sparse_index is the index in the sampled trajectory that a new point is to be added
+    // point_pos is the index into the dense trajectory that the new point is to be copied from 
     int sparse_index, point_pos;
-    int result = interpolateSparseTrajectory(sparse_solution_array_,sparse_index,point_pos);
+    int result = interpolateSparseTrajectory(sparse_solution_array_, sparse_index, point_pos);
     TrajectoryPt::ID prev_id, next_id;
     TrajectoryPtPtr cart_point;
     switch(result)
@@ -647,29 +686,53 @@ bool SparsePlanner::plan()
       case int(InterpolationResult::REPLAN):
           replan = true;
           cart_point = cart_points_[point_pos];
-
           if(sparse_index == 0)
           {
+            // If the point is being inserted at the beginning of the trajectory
+            // there is no need to tweak the timing that comes from the dense traj
             prev_id = descartes_core::TrajectoryID::make_nil();
             next_id = std::get<1>(sparse_solution_array_[sparse_index])->getID();
           }
           else
           {
+            // Here we want to calculate the time from the prev point to the new point
+            int prev_dense_id = std::get<0>(sparse_solution_array_[sparse_index-1]);
+            int next_dense_id = point_pos;
+            descartes_core::TimingConstraint tm = cumulativeTimingBetween(cart_points_, prev_dense_id, next_dense_id);
+            descartes_core::TrajectoryPtPtr copy_pt = copyAndSetTiming(cart_point, tm);
+            cart_point = copy_pt; // swap the point over
+
             prev_id = std::get<1>(sparse_solution_array_[sparse_index-1])->getID();
             next_id = std::get<1>(sparse_solution_array_[sparse_index])->getID();
           }
 
-          if(planning_graph_->addTrajectory(cart_point,prev_id,next_id))
+          // In either case, the sparse_index point will have to be recalculated
           {
-            sparse_solution_array_.clear();
-            ROS_INFO_STREAM("Added new point to sparse trajectory from dense trajectory at position "<<
-                            point_pos<<", re-planning entire trajectory");
-          }
-          else
-          {
-            ROS_ERROR_STREAM("Adding point "<<point_pos <<"to sparse trajectory failed, aborting");
-            replan = false;
-            succeeded = false;
+            int prev_dense_id = point_pos;
+            int next_dense_id = std::get<0>(sparse_solution_array_[sparse_index]);
+            descartes_core::TimingConstraint tm = cumulativeTimingBetween(cart_points_, prev_dense_id, next_dense_id);
+            descartes_core::TrajectoryPtPtr copy_pt = copyAndSetTiming(cart_points_[next_dense_id], tm);
+
+            if (!planning_graph_->modifyTrajectory(copy_pt))
+            {
+              ROS_ERROR_STREAM("Could not modify trajectory point with id: " << copy_pt->getID());
+              replan = false;
+              succeeded = false;
+            }
+
+            // Add into original trajectory
+            if(planning_graph_->addTrajectory(cart_point,prev_id,next_id))
+            {
+              sparse_solution_array_.clear();
+              ROS_INFO_STREAM("Added new point to sparse trajectory from dense trajectory at position "<<
+                              point_pos<<", re-planning entire trajectory");
+            }
+            else
+            {
+              ROS_ERROR_STREAM("Adding point "<<point_pos <<"to sparse trajectory failed, aborting");
+              replan = false;
+              succeeded = false;
+            }
           }
 
           break;
@@ -732,7 +795,7 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
     // interpolating
     int step = end_index - start_index;
     ROS_DEBUG_STREAM("Interpolation parameters: step : "<<step<<", start index "<<start_index<<", end index "<<end_index);
-    for(int j = 1; (j < step) && ( (start_index + j) < cart_points_.size()); j++)
+    for(int j = 1; (j <= step) && ( (start_index + j) < cart_points_.size()); j++)
     {
       int pos = start_index+j;
       double t = double(j)/double(step);
@@ -755,19 +818,22 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
           last_joint_pt.getNominalJointPose(std::vector<double>(), *robot_model, last_joint_pose);
 
           // retreiving timing constraint
-          const descartes_core::TimingConstraint& tm = timing_cache_[pos];
+          // TODO, let's check the timing constraints
+          const descartes_core::TimingConstraint& tm = cart_points_[pos]->getTiming();
 
           // check validity of joint motion
           if (tm.isSpecified() && !robot_model->isValidMove(last_joint_pose, aprox_interp, tm.upper))
           {
             ROS_WARN_STREAM("Joint velocity checking failed for point " << pos << ". Replanning.");
+            // The last point in an interpolated segment will always succeed (as its from the solved graph)
+            // but the timing may not be valid. We check this last point here and if it fails, the second to
+            // last point is added to the graph so that this timing is thoroughly checked by planning graph.
+            point_pos = (j == step) ? (pos - 1) : pos;
             sparse_index = k;
-            point_pos = pos;
             return static_cast<int>(InterpolationResult::REPLAN);
           }
-
-          // otherwise add point
-          joint_points_map_.insert(std::make_pair(cart_point->getID(),JointTrajectoryPt(aprox_interp)));
+          
+          joint_points_map_.insert(std::make_pair(cart_point->getID(), JointTrajectoryPt(aprox_interp, tm)));
         }
         else
         {
@@ -780,16 +846,12 @@ int SparsePlanner::interpolateSparseTrajectory(const SolutionArray& sparse_solut
       }
       else
       {
-
           ROS_WARN_STREAM("Couldn't find a closest joint pose for point "<< cart_point->getID()<<", replanning");
           sparse_index = k;
           point_pos = pos;
           return (int)InterpolationResult::REPLAN;
       }
     }
-
-    // adding end joint point to solution
-    joint_points_map_.insert(std::make_pair(end_tpoint->getID(),end_jpoint));
   }
 
   return (int)InterpolationResult::SUCCESS;

--- a/descartes_planner/src/sparse_planner.cpp
+++ b/descartes_planner/src/sparse_planner.cpp
@@ -635,7 +635,6 @@ bool SparsePlanner::plan()
   // solving coarse trajectory
   bool replan = true;
   bool succeeded = false;
-  int max_replanning_attempts = cart_points_.size();
   int replanning_attempts = 0;
   while(replan && getSparseSolutionArray(sparse_solution_array_))
   {
@@ -683,15 +682,6 @@ bool SparsePlanner::plan()
           succeeded = false;
           break;
     }
-
-    if(replanning_attempts++ > max_replanning_attempts)
-    {
-      ROS_ERROR_STREAM("Maximum number of replanning attempts exceeded, aborting");
-      replan = false;
-      succeeded = false;
-      break;
-    }
-
   }
 
   return succeeded;

--- a/descartes_planner/test/planner_tests.h
+++ b/descartes_planner/test/planner_tests.h
@@ -60,13 +60,13 @@ TYPED_TEST_P(PathPlannerTest, preservesTiming)
   input = makeConstantVelocityTrajectory(Eigen::Vector3d(-1.0, 0, 0), // start position
                                          Eigen::Vector3d(1.0, 0, 0), // end position
                                          0.9, // tool velocity
-                                         10); // samples
+                                         20); // samples
   // Double the dt of every pt to provide some variety
   double dt = input.front().get()->getTiming().upper;
   for (auto& pt : input)
   {
     pt.get()->setTiming(TimingConstraint(dt));
-    dt *= 2.0;
+    dt *= 1.5;
   }
   // // Solve
   ASSERT_TRUE(planner->planPath(input));

--- a/descartes_planner/test/planner_tests.h
+++ b/descartes_planner/test/planner_tests.h
@@ -105,5 +105,24 @@ TYPED_TEST_P(PathPlannerTest, simpleVelocityCheck)
   EXPECT_FALSE(planner->planPath(input)) << "Trajectory pt has very small dt; planner should fail for velocity out of bounds";
 }
 
+TYPED_TEST_P(PathPlannerTest, zigzagTrajectory)
+{
+  using namespace descartes_core;
+
+  PathPlannerBasePtr planner = this->makePlanner();
+
+  std::vector<descartes_core::TrajectoryPtPtr> input;
+  input = descartes_tests::makeZigZagTrajectory(-1.0, // start position
+                                                1.0, // end position
+                                                0.5,
+                                                0.1, // tool velocity (< 1.0 m/s limit)
+                                                10); // samples
+  ASSERT_TRUE(!input.empty());
+  // The nominal trajectory (0.9 m/s) is less than max tool speed of 1.0 m/s
+  EXPECT_TRUE(planner->planPath(input));
+}
+
+
 REGISTER_TYPED_TEST_CASE_P(PathPlannerTest,
-                           construction, basicConfigure, preservesTiming, simpleVelocityCheck);
+                           construction, basicConfigure, preservesTiming, 
+                           simpleVelocityCheck, zigzagTrajectory);

--- a/descartes_planner/test/utils/trajectory_maker.cpp
+++ b/descartes_planner/test/utils/trajectory_maker.cpp
@@ -24,3 +24,41 @@ descartes_tests::makeConstantVelocityTrajectory(const Eigen::Vector3d& start,
   }
   return result;
 }
+
+std::vector<descartes_core::TrajectoryPtPtr>
+descartes_tests::makeZigZagTrajectory(double x_start,
+                                      double x_stop,
+                                      double y_amplitude,
+                                      double tool_vel,
+                                      size_t n_steps)
+{
+  using namespace Eigen;
+  Vector3d start (x_start, 0, 0);
+  Vector3d stop (x_stop, 0, 0);
+
+  Eigen::Vector3d delta = stop - start;
+  Eigen::Vector3d step = delta / n_steps;
+  double dt = delta.norm() / tool_vel;
+  double time_step = dt / n_steps;
+  // We know our dt, all points should have it
+  descartes_core::TimingConstraint tm (time_step);
+
+  std::vector<descartes_core::TrajectoryPtPtr> result;
+  for (size_t i = 0; i <= n_steps; ++i)
+  {
+    Eigen::Affine3d pose;
+    pose = Eigen::Translation3d(start + i * step);
+    if (i & 1)
+    {
+      pose *= Translation3d(0, y_amplitude, 0);
+    }
+    else
+    {
+      pose *= Translation3d(0, -y_amplitude, 0); 
+    }
+    descartes_core::TrajectoryPtPtr pt (new descartes_trajectory::CartTrajectoryPt(pose, tm));
+    result.push_back(pt);
+  }
+  return result;
+
+}

--- a/descartes_planner/test/utils/trajectory_maker.h
+++ b/descartes_planner/test/utils/trajectory_maker.h
@@ -13,6 +13,15 @@ makeConstantVelocityTrajectory(const Eigen::Vector3d& start,
                                const Eigen::Vector3d& stop,
                                double tool_vel,
                                size_t n_steps);
+
+// Make a pattern that moves in a line but that oscillates along the 
+// y axis as it moves 
+std::vector<descartes_core::TrajectoryPtPtr>
+makeZigZagTrajectory(double x_start,
+                     double x_stop,
+                     double y_amplitude,
+                     double tool_vel,
+                     size_t n_steps);
 }
 
 #endif


### PR DESCRIPTION
This PR address #136, #137, and #138. 

It makes the sparse planner sample both the positions and timing values of the input trajectory. For example, after sampling the first and last point in a three point trajectory with 1 second spacing, the final point will have a 2 second spacing. This is what we've done.

This PR also removes the maximum planning attempts count, and adds a test trajectory (a zig-zag pattern) that forces sparse planner to frequently replan with the test robot model.
