### PR TITLE
ROS Utilities

### DIFF
--- a/descartes/package.xml
+++ b/descartes/package.xml
@@ -15,6 +15,7 @@
   <run_depend>descartes_moveit</run_depend>
   <run_depend>descartes_planner</run_depend>
   <run_depend>descartes_trajectory</run_depend>
+  <run_depend>descartes_utilities</run_depend>
 
   <export>
     <metapackage/>

--- a/descartes_utilities/CMakeLists.txt
+++ b/descartes_utilities/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(descartes_utilities)
+
+find_package(catkin REQUIRED COMPONENTS
+  descartes_core
+  descartes_trajectory
+  trajectory_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES descartes_utilities
+  CATKIN_DEPENDS descartes_core descartes_trajectory trajectory_msgs
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}
+  src/ros_conversions.cpp
+)
+
+add_dependencies(${PROJECT_NAME} 
+  ${catkin_EXPORTED_TARGETS}
+)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)

--- a/descartes_utilities/include/descartes_utilities/ros_conversions.h
+++ b/descartes_utilities/include/descartes_utilities/ros_conversions.h
@@ -1,0 +1,51 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  ros_conversions.h
+ *
+ *  Created on: Feb 28, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#ifndef DESCARTES_ROS_CONVERSIONS_H
+#define DESCARTES_ROS_CONVERSIONS_H
+
+#include <trajectory_msgs/JointTrajectory.h>
+#include <descartes_core/trajectory_pt.h>
+
+namespace descartes_utilities
+{
+  /**
+   * @brief Converts a sequence of Descartes joint trajectory points to ROS trajectory points.
+   *        Copies timing if specified, and sets vel/acc/effort fields to zeros.
+   * @param model Descartes robot model associated with the Descartes joint trajectory
+   * @param joint_traj Sequence of 'joint trajectory points' as returned by Dense/Sparse planner 
+   * @param default_joint_vel If a point, does not have timing specified, this value (in rads/s)
+   *                          is used to calculate a 'default' time. Must be > 0 & less than 100.
+   * @param out Buffer in which to store the resulting ROS trajectory. Only overwritten on success.
+   * @return True if the conversion succeeded. False otherwise.
+   */
+  bool
+  toRosJointPoints(const descartes_core::RobotModel& model,
+                   const std::vector<descartes_core::TrajectoryPtPtr>& joint_traj,
+                   double default_joint_vel,
+                   std::vector<trajectory_msgs::JointTrajectoryPoint>& out);
+}
+
+#endif
+

--- a/descartes_utilities/package.xml
+++ b/descartes_utilities/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>descartes_utilities</name>
+  <version>0.0.1</version>
+  <description>
+    This package contains helper routines for working with the Descartes motion planning library
+    that ease practical use, but do fit cleanly into the core library. This includes conversions
+    to ROS trajectories, and similar operations.
+  </description>
+
+  <maintainer email="Jmeyer@swri.org">Jonathan Meyer</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  
+  <build_depend>descartes_core</build_depend>
+  <build_depend>descartes_trajectory</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
+  
+  <run_depend>descartes_core</run_depend>
+  <run_depend>descartes_trajectory</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
+
+</package>

--- a/descartes_utilities/src/ros_conversions.cpp
+++ b/descartes_utilities/src/ros_conversions.cpp
@@ -1,0 +1,121 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  ros_conversions.cpp
+ *
+ *  Created on: Feb 28, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#include "descartes_utilities/ros_conversions.h"
+#include <algorithm>
+#include <console_bridge/console.h>
+
+/**
+ * @brief Given two sets of joint values representing two robot joint poses, this function computes the
+ *        minimum amount of time required to interpolate between the points assuming that each joint can
+ *        move no faster than a constant 'max_vel' speed.
+ * @return The minimum time required to interpolate between poses.
+ */
+static double minTime(const std::vector<double>& pose_a, const std::vector<double>& pose_b, double max_vel)
+{
+  std::vector<double> diff;
+  diff.reserve(pose_a.size());
+
+  // compute joint-wise minimum time required based on relative distance between joint positions
+  // and the maximum allowable joint velocity
+  std::transform(pose_a.begin(), pose_a.end(), pose_b.begin(), std::back_inserter(diff), [max_vel] (double a, double b) {
+    return std::abs(a - b) / max_vel;
+  });
+  // The biggest time across all of the joints is the min time
+  return *std::max_element(diff.begin(), diff.end());
+}
+
+bool
+descartes_utilities::toRosJointPoints(const descartes_core::RobotModel& model,
+                                      const std::vector<descartes_core::TrajectoryPtPtr>& joint_traj,
+                                      double default_joint_vel,
+                                      std::vector<trajectory_msgs::JointTrajectoryPoint>& out)
+{
+  if (default_joint_vel <= 0.0)
+  {
+    logError("%s: Invalid value for default joint velocity. Must be > 0 (radians/second)", __FUNCTION__);
+    return false;
+  }
+
+  const static double max_default_joint_velocity = 100.0; // (radians / s); approx 1000 rpm
+  if (default_joint_vel > max_default_joint_velocity)
+  {
+    logError("%s: Default joint velocity of %f exceeds assumed limit of %f.", __FUNCTION__, default_joint_vel, max_default_joint_velocity);
+    return false;
+  }
+
+  ros::Duration from_start (0.0);
+  std::vector<trajectory_msgs::JointTrajectoryPoint> ros_trajectory;
+  ros_trajectory.reserve(joint_traj.size());
+
+  std::vector<double> joint_point;
+  std::vector<double> dummy;
+
+  for (std::size_t i = 0; i < joint_traj.size(); ++i)
+  {
+    if (!joint_traj[i])
+    {
+      logError("%s: Input trajectory contained null pointer at index %lu", __FUNCTION__, static_cast<unsigned long>(i));
+      return false;
+    }
+
+    descartes_core::TrajectoryPt& pt = *joint_traj[i];
+
+    if (!pt.getNominalJointPose(dummy, model, joint_point))
+    {
+      logError("%s: Failed to extract joint positions from input trajectory at index %lu", __FUNCTION__, static_cast<unsigned long>(i));
+      return false;
+    }
+
+    trajectory_msgs::JointTrajectoryPoint ros_pt;
+    ros_pt.positions = joint_point;
+    // Descartes has no internal representation of velocity, acceleration, or effort so we fill these field with zeros.
+    ros_pt.velocities.resize(joint_point.size(), 0.0);
+    ros_pt.accelerations.resize(joint_point.size(), 0.0);
+    ros_pt.effort.resize(joint_point.size(), 0.0);
+
+    if (pt.getTiming().isSpecified())
+    {
+      from_start += ros::Duration(pt.getTiming().upper);
+    }
+    else
+    {
+      // If we have a previous point, compute dt based on default, max joint velocity
+      // otherwise trajectory starts at current location (time offset == 0).
+      double dt;
+      if (i == 0)
+        dt = 0.0;
+      else
+        dt = minTime(joint_point, ros_trajectory.back().positions, default_joint_vel);
+
+      from_start += ros::Duration(dt);
+    }
+
+    ros_pt.time_from_start = from_start;
+    ros_trajectory.push_back(ros_pt);
+  }
+
+  out = ros_trajectory;
+  return true;
+}


### PR DESCRIPTION
This PR introduces a new package `descartes_utilities` which currently exposes one file, `ros_conversions.h` that can be used to convert a Descartes trajectory to a standard vector of ROS JointTrajectoryPoints.

This is an extremely common task, and I find the same code sprinkled through every project that integrates Descartes with a ROS interface. In the future, I imagine this package as a home for other useful utilities for inputting and outputting trajectories through the Descartes motion planner. 
