### PR TITLE
Update CI config usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".ci_config"]
-	path = .ci_config
-	url = https://github.com/ros-industrial/industrial_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - USE_DEB=true  
       ROS_DISTRO="indigo" 
       ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh


### PR DESCRIPTION
`git clone` is the recommended usage of `industrial_ci` from version 0.1.1 to use its latest code (currently with `git submodule` method, you have to manually update the submodule to point to newer code).
Ref. [readme](https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#to-start-using-ci-config-stored-in-this-repo).
