### PR TITLE
Various Cleanups in Planning Graph

### DIFF
--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -74,6 +74,7 @@ struct CartesianPointInformation
 };
 
 typedef std::map<descartes_core::TrajectoryPt::ID, CartesianPointInformation> CartesianMap;
+typedef std::map<descartes_core::TrajectoryPt::ID, descartes_trajectory::JointTrajectoryPt> JointMap;
 
 class PlanningGraph
 {
@@ -144,11 +145,11 @@ protected:
   //       and include an accessor to both formats
 
   // maintains the original (Cartesian) points list along with link information and associated joint trajectories per point
-  std::map<descartes_core::TrajectoryPt::ID, CartesianPointInformation> *cartesian_point_link_;
+  CartesianMap* cartesian_point_link_;
 
   // maintains a map of joint solutions with it's corresponding graph vertex_descriptor
   //   one or more of these will exist for each element in trajectory_point_map
-  std::map<descartes_core::TrajectoryPt::ID, descartes_trajectory::JointTrajectoryPt> joint_solutions_map_;
+  JointMap joint_solutions_map_;
 
   /** @brief simple function to iterate over all graph vertices to find ones that do not have an incoming edge */
   bool findStartVertices(std::list<JointGraph::vertex_descriptor> &start_points);

--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -70,11 +70,12 @@ struct CartesianPointInformation
 {
   CartesianPointRelationship links_;
   descartes_core::TrajectoryPtPtr source_trajectory_;
-  std::list<descartes_core::TrajectoryPt::ID> joints_;
+  std::vector<descartes_core::TrajectoryPt::ID> joints_;
 };
 
 typedef std::map<descartes_core::TrajectoryPt::ID, CartesianPointInformation> CartesianMap;
 typedef std::map<descartes_core::TrajectoryPt::ID, descartes_trajectory::JointTrajectoryPt> JointMap;
+typedef std::map<descartes_core::TrajectoryPt::ID, JointGraph::vertex_descriptor> VertexMap;
 
 class PlanningGraph
 {
@@ -100,7 +101,7 @@ public:
 
   bool removeTrajectory(descartes_core::TrajectoryPtPtr point);
 
-  CartesianMap getCartesianMap();
+  CartesianMap getCartesianMap() const;
 
   bool getCartesianTrajectory(std::vector<descartes_core::TrajectoryPtPtr>& traj);
 
@@ -152,10 +153,10 @@ protected:
   JointMap joint_solutions_map_;
 
   /** @brief simple function to iterate over all graph vertices to find ones that do not have an incoming edge */
-  bool findStartVertices(std::list<JointGraph::vertex_descriptor> &start_points);
+  bool findStartVertices(std::vector<JointGraph::vertex_descriptor> &start_points);
 
   /** @brief simple function to iterate over all graph vertices to find ones that do not have an outgoing edge */
-  bool findEndVertices(std::list<JointGraph::vertex_descriptor> &end_points);
+  bool findEndVertices(std::vector<JointGraph::vertex_descriptor> &end_points);
 
   /** @brief (Re)create the list of joint solutions from the given descartes_core::TrajectoryPt list */
   bool calculateJointSolutions();
@@ -164,14 +165,15 @@ protected:
   bool populateGraphVertices();
 
   /** @brief calculate weights fro each start point to each end point */
-  bool calculateEdgeWeights(const std::list<descartes_core::TrajectoryPt::ID> &start_joints,
-                            const std::list<descartes_core::TrajectoryPt::ID> &end_joints, std::list<JointEdge> &edge_results);
+  bool calculateEdgeWeights(const std::vector<descartes_core::TrajectoryPt::ID> &start_joints,
+                            const std::vector<descartes_core::TrajectoryPt::ID> &end_joints,
+                            std::vector<JointEdge> &edge_results);
 
   /** @brief (Re)populate the edge list for the graph from the list of joint solutions */
-  bool calculateAllEdgeWeights(std::list<JointEdge> &edges);
+  bool calculateAllEdgeWeights(std::vector<JointEdge> &edges);
 
   /** @brief (Re)create the actual graph structure from the list of transition costs (edges) */
-  bool populateGraphEdges(const std::list<JointEdge> &edges);
+  bool populateGraphEdges(const std::vector<JointEdge> &edges);
 };
 
 } /* namespace descartes_planner */


### PR DESCRIPTION
This PR helps assuage my OCD by doing a few minor, but important things to the core planning graph source file:
1. Moves several key INFO print statements to DEBUG statements. Descartes should now output no more than 3 lines on success. Warnings unchanged.
2. Replaces iterator types with `auto` keyword and created some high level typedefs. This makes the code shorter, easier to read, and should allow us to experiment with other data structures (perhaps a hash-map instead of a balanced tree?) more easily.
3. `std::list` is replaced with `std::vector` everywhere but the primary interfaces. There's no need for the properties of list, so vector gets us better memory usage, better cache coherency, etc... 

Unit tests still pass and I made sure to test with a Godel simulation.
