### PR TITLE
Edge Building Refactor

### DIFF
--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -173,7 +173,7 @@ protected:
 
   bool calculateEdgeWeights(const std::vector<descartes_trajectory::JointTrajectoryPt> &start_joints,
                             const std::vector<descartes_trajectory::JointTrajectoryPt> &end_joints,
-                            std::vector<JointEdge> &edge_results);
+                            std::vector<JointEdge> &edge_results) const;
 
   /** @brief (Re)populate the edge list for the graph from the list of joint solutions */
   bool calculateAllEdgeWeights(const std::vector<std::vector<descartes_trajectory::JointTrajectoryPt>>& poses,

--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -159,18 +159,25 @@ protected:
   bool findEndVertices(std::vector<JointGraph::vertex_descriptor> &end_points);
 
   /** @brief (Re)create the list of joint solutions from the given descartes_core::TrajectoryPt list */
-  bool calculateJointSolutions();
+  bool calculateJointSolutions(const std::vector<descartes_core::TrajectoryPtPtr>& points,
+                               std::vector<std::vector<descartes_trajectory::JointTrajectoryPt>>& poses);
 
   /** @brief (Re)create the actual graph nodes(vertices) from the list of joint solutions (vertices) */
-  bool populateGraphVertices();
+  bool populateGraphVertices(const std::vector<descartes_core::TrajectoryPtPtr>& points,
+                             std::vector<std::vector<descartes_trajectory::JointTrajectoryPt>>& poses);
 
   /** @brief calculate weights fro each start point to each end point */
   bool calculateEdgeWeights(const std::vector<descartes_core::TrajectoryPt::ID> &start_joints,
                             const std::vector<descartes_core::TrajectoryPt::ID> &end_joints,
                             std::vector<JointEdge> &edge_results);
 
+  bool calculateEdgeWeights(const std::vector<descartes_trajectory::JointTrajectoryPt> &start_joints,
+                            const std::vector<descartes_trajectory::JointTrajectoryPt> &end_joints,
+                            std::vector<JointEdge> &edge_results);
+
   /** @brief (Re)populate the edge list for the graph from the list of joint solutions */
-  bool calculateAllEdgeWeights(std::vector<JointEdge> &edges);
+  bool calculateAllEdgeWeights(const std::vector<std::vector<descartes_trajectory::JointTrajectoryPt>>& poses,
+                               std::vector<JointEdge> &edges);
 
   /** @brief (Re)create the actual graph structure from the list of transition costs (edges) */
   bool populateGraphEdges(const std::vector<JointEdge> &edges);


### PR DESCRIPTION
Related to #151, this PR refactors the graph building process by generating all of the joint solutions and then putting off adding them to the tree until after all the edges have been calculated. This prevents us from doing a lot of unnecessary tree searching.

To accomplish this, I needed to create a `calculateEdges` function that took a sequence of joint positions, not trajectory IDs. This function is used in many other places in the code, however, and I didn't want to touch those. Someday soon I'll get around to looking carefully at the add/remove/modify functions.
