### PR TITLE
Spline Interpolator Class & Utility Functions

### DIFF
--- a/descartes_utilities/CMakeLists.txt
+++ b/descartes_utilities/CMakeLists.txt
@@ -10,7 +10,10 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES descartes_utilities
-  CATKIN_DEPENDS descartes_core descartes_trajectory trajectory_msgs
+  CATKIN_DEPENDS 
+    descartes_core 
+    descartes_trajectory 
+    trajectory_msgs
 )
 
 include_directories(
@@ -20,7 +23,10 @@ include_directories(
 
 add_library(${PROJECT_NAME}
   src/ros_conversions.cpp
+  src/spline_interpolator.cpp
+  src/parameterization.cpp
 )
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_dependencies(${PROJECT_NAME} 
   ${catkin_EXPORTED_TARGETS}
@@ -36,3 +42,12 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
 )
+
+if(CATKIN_ENABLE_TESTING)
+  set(UTEST_SRC_FILES 
+      test/utest.cpp
+      test/parameterization_tests.cpp
+  )
+  catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
+  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
+endif()

--- a/descartes_utilities/include/descartes_utilities/parameterization.h
+++ b/descartes_utilities/include/descartes_utilities/parameterization.h
@@ -48,11 +48,38 @@ bool toCubicSplines(const std::vector<trajectory_msgs::JointTrajectoryPoint>& tr
  * Calculates velocity and acceleration values for a joint trajectory based on natural cubic splines
  * fit to the input trajectory. This function assumes that the 'positions' field of the trajectory
  * has been filled out for each point and that the degrees of freedom does not change.
- * @param  traj The input trajectory on which to act; assumed to have 'positions' field filled out.
- *              This function will populate 'velocities' and 'accelerations'.
+ * @param  traj The input trajectory on which to act; assumed to have 'positions' & 'time_from_start'
+ *              fields filled out. This function will populate 'velocities' and 'accelerations'.
  * @return      True if the operation succeeded. False otherwise.
  */ 
 bool setDerivatesFromSplines(std::vector<trajectory_msgs::JointTrajectoryPoint>& traj);
+
+/**
+ * Calculates velocity and acceleration values for a joint trajectory based on natural cubic splines
+ * provided by the caller. This function assumes that the 'positions' field of the trajectory
+ * has been filled out for each point and that the degrees of freedom does not change.
+ * @param  splines Set of splines describing the behaviour of each joint as it moves through the
+ *                 input trajectory.
+ * @param  traj The input trajectory on which to act; assumed to have 'positions' & 'time_from_start'
+ *              fields filled out. This function will populate 'velocities' and 'accelerations'.
+ * @return      True if the operation succeeded. False otherwise.
+ */
+bool setDerivatesFromSplines(const std::vector<SplineInterpolator>& splines,
+                             std::vector<trajectory_msgs::JointTrajectoryPoint>& traj);
+/**
+ * Given a set of splines describing the motion of each joint as it moves through a trajectory,
+ * sample this spline at regular intervals to generate a new trajectory.
+ * @param  splines  Sequence of splines describing the motion of each joint; 
+ *                  perhaps calculated by 'toCubicSplines'
+ * @param  start_tm The time value of the trajectory at which to start sampling
+ * @param  end_tm   The time value of the trajectory at which to end sampling
+ * @param  tm_step  The interval at which to sample times between start & end
+ * @param  traj     The new, resampled, output trajectory
+ * @return          True on success; If false, 'traj' is untouched.
+ */
+bool resampleTrajectory(const std::vector<SplineInterpolator>& splines,
+                        double start_tm, double end_tm, double tm_step,
+                        std::vector<trajectory_msgs::JointTrajectoryPoint>& traj);
 
 }
 

--- a/descartes_utilities/include/descartes_utilities/parameterization.h
+++ b/descartes_utilities/include/descartes_utilities/parameterization.h
@@ -1,0 +1,59 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  parameterization.h
+ *
+ *  Created on: March 28, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#ifndef DESCARTES_PARAMETERIZATION_H
+#define DESCARTES_PARAMETERIZATION_H
+
+#include <trajectory_msgs/JointTrajectory.h>
+#include "descartes_utilities/spline_interpolator.h"
+
+namespace descartes_utilities
+{
+
+/**
+ * @brief Given an input trajectory with positions and time_from_start specified,
+ *        generates a set of cubic splines that describe the behavior of each 
+ *        joint.
+ *        
+ * @param traj Input trajectory with positions and times specified.  
+ * @param splines If successful, this field will be populated with splines for each
+ *                joint.
+ * @return True on success, false otherwise
+ */
+bool toCubicSplines(const std::vector<trajectory_msgs::JointTrajectoryPoint>& traj,
+                    std::vector<SplineInterpolator>& splines);
+
+/**
+ * Calculates velocity and acceleration values for a joint trajectory based on natural cubic splines
+ * fit to the input trajectory. This function assumes that the 'positions' field of the trajectory
+ * has been filled out for each point and that the degrees of freedom does not change.
+ * @param  traj The input trajectory on which to act; assumed to have 'positions' field filled out.
+ *              This function will populate 'velocities' and 'accelerations'.
+ * @return      True if the operation succeeded. False otherwise.
+ */ 
+bool setDerivatesFromSplines(std::vector<trajectory_msgs::JointTrajectoryPoint>& traj);
+
+}
+
+#endif

--- a/descartes_utilities/include/descartes_utilities/ros_conversions.h
+++ b/descartes_utilities/include/descartes_utilities/ros_conversions.h
@@ -45,6 +45,16 @@ namespace descartes_utilities
                    const std::vector<descartes_core::TrajectoryPtPtr>& joint_traj,
                    double default_joint_vel,
                    std::vector<trajectory_msgs::JointTrajectoryPoint>& out);
+
+  /**
+   * Calculates velocity and acceleration values for a joint trajectory based on natural cubic splines
+   * fit to the input trajectory. This function assumes that the 'positions' field of the trajectory
+   * has been filled out for each point and that the degrees of freedom does not change.
+   * @param  traj The input trajectory on which to act; assumed to have 'positions' field filled out.
+   *              This function will populate 'velocities' and 'accelerations'.
+   * @return      True if the operation succeeded. False otherwise.
+   */
+  bool parameterizeVelocityAcceleration(std::vector<trajectory_msgs::JointTrajectoryPoint>& traj);
 }
 
 #endif

--- a/descartes_utilities/include/descartes_utilities/spline_interpolator.h
+++ b/descartes_utilities/include/descartes_utilities/spline_interpolator.h
@@ -1,0 +1,162 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  spline_interpolator.h
+ *
+ *  Created on: March 25, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#ifndef DESCARTES_SPLINE_INTERPOLATOR_H
+#define DESCARTES_SPLINE_INTERPOLATOR_H
+
+#include <vector>
+
+namespace descartes_utilities
+{
+
+/**
+ * Helper struct to store the parameters of a cubic spline:
+ *   f(x) = a + bx + cx^2 + dx^3
+ */
+struct CubicSplineParams
+{
+  CubicSplineParams() = default;
+  CubicSplineParams(double a, double b, double c, double d)
+    : coeffs {a,b,c,d}
+  {}
+  
+  double coeffs[4];
+
+  double a() const { return coeffs[0]; }
+  double b() const { return coeffs[1]; }
+  double c() const { return coeffs[2]; }
+  double d() const { return coeffs[3]; }
+
+  /**
+   * Computes f(x) at given x
+   */
+  double position(double x) const;
+
+  /**
+   * Computes df/dx at given x
+   */
+  double velocity(double x) const;
+
+  /**
+   * Computes ddf/ddx at given x
+   */
+  double acceleration(double x) const;
+
+  /**
+   * Computes the 'x' position that maximizes the velocity
+   */
+  double xMaxVelocity() const;
+
+  /**
+   * Computes the 'x' position that maximizes the acceleration
+   */
+  double xMaxAcceleration() const;
+};
+
+/**
+ * Builds a sequence of cubic splines between each pair of sequential inputs
+ * such that positions are obeyed absolutely, velocities are smooth & continous
+ * and accelerations are continous.
+ */
+class SplineInterpolator
+{
+public:
+  /**
+   * The constructor builds the set of cubic splines for an input function defined by
+   * 'x_data', and 'y_data'. 'x_data' and 'y_data' are assumed to be the same length (> 1).
+   * 'x_data' must be sorted in ascending order.  
+   */
+  SplineInterpolator(const std::vector<double>& x_data, const std::vector<double>& y_data,
+                     double init_velocity = 0.0, double final_velocity = 0.0);
+
+  /**
+   * Query the position of the curve at a given time or 'x' coordinate. Times outside the
+   * bounds determined by the first/last point in 'x_data' are interpolated based on the
+   * first/last cubic spline segment respectively.
+   */
+  double position(double x) const;
+  
+  /**
+   * Query the velocity of the curve at a given time or 'x' coordinate. Times outside the
+   * bounds determined by the first/last point in 'x_data' are interpolated based on the
+   * first/last cubic spline segment respectively.
+   */
+  double velocity(double x) const;
+
+  /**
+   * Query the acceleration of the curve at a given time or 'x' coordinate. Times outside the
+   * bounds determined by the first/last point in 'x_data' are interpolated based on the
+   * first/last cubic spline segment respectively.
+   */
+  double acceleration(double x) const;
+
+  /**
+   * Returns the maximum velocity in the spline-interpolated trajectory.
+   * @return A std::pair where the first element is the magnitude of the maximum velocity
+   *         and the second value is the trajectory segment in which this velocity occurs.
+   */
+  std::pair<double, unsigned> maxVelocity() const;
+  
+  /**
+   * Returns the maximum acceleration in the spline-interpolated trajectory.
+   * @return A std::pair where the first element is the magnitude of the maximum acceleration
+   *         and the second value is the trajectory segment in which this velocity occurs.
+   */  
+  std::pair<double, unsigned> maxAcceleration() const;
+  
+  /**
+   * Returns a reference to the 'x_data' used to construct the cubic splines.
+   */
+  const std::vector<double> xData() const { return x_data_; }
+
+  /**
+   * Returns a reference to the cubic spline segments constructed from 'x_data' and 'y_data'. 
+   */
+  const std::vector<CubicSplineParams> splineParams() const { return spline_params_; }
+
+private:
+  /**
+   * Returns the cubic segment in which 'x' resides. If x is greater than the
+   * last x value in the input, the last segment is returned. If x is less than
+   * the x value in the input, the first is returned.
+   */
+  unsigned search(double x) const;
+  
+  /**
+   * Returns the maximum velocity for a given spline segment.
+   */
+  double maxSegmentVelocity(unsigned idx) const;
+  
+  /**
+   * Returns the maximum acceleration for a given spline segment.
+   */
+  double maxSegmentAcceleration(unsigned idx) const;
+
+  std::vector<double> x_data_;
+  std::vector<CubicSplineParams> spline_params_;
+};
+
+}
+
+#endif

--- a/descartes_utilities/package.xml
+++ b/descartes_utilities/package.xml
@@ -11,6 +11,7 @@
   <maintainer email="Jmeyer@swri.org">Jonathan Meyer</maintainer>
 
   <license>Apache 2.0</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   

--- a/descartes_utilities/src/parameterization.cpp
+++ b/descartes_utilities/src/parameterization.cpp
@@ -53,9 +53,10 @@ bool descartes_utilities::toCubicSplines(const std::vector<trajectory_msgs::Join
   {
     // check time to ensure consistency
     const auto tm = traj[i].time_from_start.toSec();
-    if (tm < last_time_seen)
+    if (i > 0 && tm <= last_time_seen)
     {
-      logError("%s: 'time_from_start' fields must be sorted in increasing order", __FUNCTION__);
+      logError("%s: 'time_from_start' fields must be sorted in increasing order (index %lu = %f, index %lu = %f)", 
+        __FUNCTION__, static_cast<unsigned long>(i-1), last_time_seen, static_cast<unsigned long>(i), tm);
       return false;
     }
 
@@ -67,8 +68,9 @@ bool descartes_utilities::toCubicSplines(const std::vector<trajectory_msgs::Join
     // check to make sure nothing funky about the size of the positions
     if (traj[i].positions.size() != dof)
     {
-      logError("%s: 'Positions' field of trajectory point at index %u does not have the same size as first",
-        __FUNCTION__, static_cast<unsigned>(i));
+      logError("%s: 'Positions' field of trajectory point at index %lu does not have the same size as first (%lu vs %lu)",
+        __FUNCTION__, static_cast<unsigned long>(i), static_cast<unsigned long>(dof), 
+        static_cast<unsigned long>(traj[i].positions.size()));
       return false;
     }
 
@@ -97,12 +99,26 @@ bool descartes_utilities::setDerivatesFromSplines(std::vector<trajectory_msgs::J
     return false;
   }
 
+  return setDerivatesFromSplines(splines, traj);
+}
+
+bool descartes_utilities::setDerivatesFromSplines(const std::vector<SplineInterpolator>& splines,
+                                                  std::vector<trajectory_msgs::JointTrajectoryPoint>& traj)
+{
   const auto dof = splines.size();
 
   // Sample each parameter at the nominal time point
   for (auto& pt : traj)
   {
     auto tm = pt.time_from_start.toSec();
+
+    // sanity check the DOF of the splines with the DOF of the input path
+    if (pt.positions.size() != dof)
+    {
+      logError("%s: Splines vector is of size %lu and input trajectory point (time %f) has 'positions' field of size %lu",
+        __FUNCTION__, static_cast<unsigned long>(dof), tm, static_cast<unsigned long>(pt.positions.size()));
+      return false;
+    }
 
     // ensure there is room
     if (pt.velocities.size() != dof) pt.velocities.resize(dof);
@@ -116,5 +132,41 @@ bool descartes_utilities::setDerivatesFromSplines(std::vector<trajectory_msgs::J
     }
   }
 
+  return true;
+}
+
+bool descartes_utilities::resampleTrajectory(const std::vector<SplineInterpolator>& splines,
+                                             double start_tm, double end_tm, double tm_step,
+                                             std::vector<trajectory_msgs::JointTrajectoryPoint>& traj)
+{
+  if (start_tm >= end_tm)
+  {
+    logError("%s: 'start_tm' must be greater than or equal to 'end_tm' (%f vs %f)", __FUNCTION__,
+      start_tm, end_tm);
+    return false;
+  }
+
+  const auto dof = splines.size();
+  std::vector<trajectory_msgs::JointTrajectoryPoint> new_traj;
+
+  for (double tm = start_tm; tm < end_tm; tm += tm_step)
+  {
+    auto pt = trajectory_msgs::JointTrajectoryPoint();
+    pt.positions.resize(dof);
+    pt.velocities.resize(dof);
+    pt.accelerations.resize(dof);
+    pt.time_from_start = ros::Duration(tm);
+
+    for (auto i = 0; i < dof; i++)
+    {
+      pt.positions[i] = splines[i].position(tm);
+      pt.velocities[i] = splines[i].velocity(tm);
+      pt.accelerations[i] = splines[i].acceleration(tm);
+    }
+
+    new_traj.push_back(pt);
+  }
+
+  traj = new_traj;
   return true;
 }

--- a/descartes_utilities/src/parameterization.cpp
+++ b/descartes_utilities/src/parameterization.cpp
@@ -1,0 +1,120 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  parameterization.cpp
+ *
+ *  Created on: March 28, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#include "descartes_utilities/parameterization.h"
+#include <console_bridge/console.h>
+
+bool descartes_utilities::toCubicSplines(const std::vector<trajectory_msgs::JointTrajectoryPoint>& traj,
+                                         std::vector<SplineInterpolator>& splines)
+{
+  if (traj.size() < 2)
+  {
+    logError("%s: Can not parameterize trajectory with fewer than 2 points", __FUNCTION__);
+    return false;
+  }
+
+  // determine size of trajectory points
+  const auto n = traj.size();
+  const auto dof = traj.front().positions.size();
+  
+  // build data structures for time and position at each point
+  std::vector<std::vector<double>> joint_values (dof);
+  std::vector<double> time_values (n);
+  for (auto& joint_vec : joint_values)
+  {
+    joint_vec.resize(n);
+  }
+
+  auto last_time_seen = traj.front().time_from_start.toSec();
+
+  // Fill out data structures
+  for (std::size_t i = 0; i < traj.size(); ++i)
+  {
+    // check time to ensure consistency
+    const auto tm = traj[i].time_from_start.toSec();
+    if (tm < last_time_seen)
+    {
+      logError("%s: 'time_from_start' fields must be sorted in increasing order", __FUNCTION__);
+      return false;
+    }
+
+    // copy time
+    time_values[i] = tm;
+    // update last time seen
+    last_time_seen = tm;
+    
+    // check to make sure nothing funky about the size of the positions
+    if (traj[i].positions.size() != dof)
+    {
+      logError("%s: 'Positions' field of trajectory point at index %u does not have the same size as first",
+        __FUNCTION__, static_cast<unsigned>(i));
+      return false;
+    }
+
+    // copy joints
+    for (std::size_t j = 0; j < dof; ++j)
+    {
+      joint_values[j][i] = traj[i].positions[j];
+    }
+  }
+
+  // fit splines
+  for (const auto& joint_vec : joint_values)
+  {
+    splines.emplace_back(time_values, joint_vec, 0.0, 0.0);
+  }
+
+  return true;
+}
+
+bool descartes_utilities::setDerivatesFromSplines(std::vector<trajectory_msgs::JointTrajectoryPoint>& traj)
+{
+  std::vector<SplineInterpolator> splines;
+  if (!toCubicSplines(traj, splines))
+  {
+    logError("%s: Unable to compute splines for input trajectory", __FUNCTION__);
+    return false;
+  }
+
+  const auto dof = splines.size();
+
+  // Sample each parameter at the nominal time point
+  for (auto& pt : traj)
+  {
+    auto tm = pt.time_from_start.toSec();
+
+    // ensure there is room
+    if (pt.velocities.size() != dof) pt.velocities.resize(dof);
+    if (pt.accelerations.size() != dof) pt.accelerations.resize(dof);
+
+    // sample values
+    for (std::size_t j = 0; j < dof; ++j)
+    {
+      pt.velocities[j] = splines[j].velocity(tm);
+      pt.accelerations[j] = splines[j].acceleration(tm);
+    }
+  }
+
+  return true;
+}

--- a/descartes_utilities/src/ros_conversions.cpp
+++ b/descartes_utilities/src/ros_conversions.cpp
@@ -23,8 +23,6 @@
  */
 
 #include "descartes_utilities/ros_conversions.h"
-#include <algorithm>
-#include <console_bridge/console.h>
 
 /**
  * @brief Given two sets of joint values representing two robot joint poses, this function computes the

--- a/descartes_utilities/src/spline_interpolator.cpp
+++ b/descartes_utilities/src/spline_interpolator.cpp
@@ -1,0 +1,232 @@
+/**
+  Copyright (c) 2016, Southwest Research Institute
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the <organization> nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "descartes_utilities/spline_interpolator.h"
+#include <cassert>
+#include <cmath>
+#include <algorithm>
+
+/*
+  This code does the heavy lifting of solving the constraints matrix.
+  
+  Taken partially from Daniel Stonier's ecl spline implementation:
+    https://github.com/stonier/ecl_core/tree/indigo-devel/ecl_geometry
+
+  which in turns draws the algorithm from:
+    This algorithm can be found in page 115 of "Numerical Recipes in C"
+    [The art of scientific computing] by Press, Vetterling, Tuekolsky, Flannery.
+*/
+static void fit_splines(const std::vector<double>& x_data, const std::vector<double>& y_data,
+                        double init_velocity, double final_velocity, std::vector<double>& yddot_data)
+{
+  const auto n = x_data.size(); 
+  std::vector<double> u(n);  // u is a temporary used in the algorithm
+
+  // Initial boundary conditions
+  yddot_data[0] = -0.5;
+  u[0] = (3.0/(x_data[1]-x_data[0])) * ((y_data[1]-y_data[0])/(x_data[1]-x_data[0])-init_velocity);
+  // Set up the tridiagonal matrix to solve for the accelerations
+  for (unsigned int i = 1; i <= n-2; ++i) 
+  {
+      double sig = (x_data[i]-x_data[i-1]) / (x_data[i+1]-x_data[i-1]);
+      double p = sig*yddot_data[i-1]+2.0;
+      yddot_data[i] = (sig-1.0)/p;
+      u[i] = (y_data[i+1]-y_data[i])/(x_data[i+1]-x_data[i]) -
+      (y_data[i]-y_data[i-1])/(x_data[i]-x_data[i-1]);
+      u[i] = (6.0*u[i]/(x_data[i+1]-x_data[i-1]) - sig*u[i-1])/p;
+  }
+  // Final boundary conditions
+  double qn = 0.5;
+  u[n-1] = (3.0/(x_data[n-1]-x_data[n-2])) * (final_velocity - (y_data[n-1]-y_data[n-2])/(x_data[n-1]-x_data[n-2]));
+
+  // Back substitution loop of the tridiagonal algorithm
+  yddot_data[n-1] = ( u[n-1] - qn*u[n-2]) / ( qn*yddot_data[n-2] + 1.0 );
+  for ( int k = n-2; k >= 0; --k ) 
+  {
+    yddot_data[k] = yddot_data[k]*yddot_data[k+1] + u[k];
+  }
+}
+
+////////////////////////////////
+// Cubic Spline Segment Implemenation //
+////////////////////////////////
+double descartes_utilities::CubicSplineParams::position(double x) const
+{
+  return a() + b() * x + c() * std::pow(x, 2) + d() * std::pow(x, 3);
+}
+
+double descartes_utilities::CubicSplineParams::velocity(double x) const
+{
+  return b() + 2 * x * c() + 3 * d() * std::pow(x, 2);
+}
+
+double descartes_utilities::CubicSplineParams::acceleration(double x) const
+{
+  return 2 * c() + 6 * x * d();
+}
+
+double descartes_utilities::CubicSplineParams::xMaxVelocity() const
+{
+  return -1.0 / 3.0 * c() / d();
+}
+
+double descartes_utilities::CubicSplineParams::xMaxAcceleration() const
+{
+  return 6 * d();
+}
+
+/////////////////////////
+// Spline Interpolator //
+/////////////////////////
+descartes_utilities::SplineInterpolator::SplineInterpolator(const std::vector<double>& x_data, 
+                                                            const std::vector<double>& y_data,
+                                                            double init_velocity, 
+                                                            double final_velocity)
+  : x_data_(x_data)
+{
+  // Asserts
+  assert(x_data.size() > 1);
+  assert(x_data.size() == y_data.size());
+  // Memory efficiency
+  spline_params_.reserve(x_data.size() - 1);
+  
+  const auto n = x_data.size();
+  std::vector<double> yddot_data (n); // temporary storage for accelerations
+  
+  fit_splines(x_data, y_data, init_velocity, final_velocity, yddot_data);
+
+  // Convert to spline parameters and save
+  for (std::size_t i = 0; i < x_data_.size() - 1; ++i)
+  {
+    auto start = i;
+    auto end = i + 1;
+    double dt = x_data[end] - x_data[start];
+    double a = y_data[start];
+    double c = yddot_data[start] / 2.0;
+    double d = (yddot_data[end] - yddot_data[start]) / (6 * dt);
+    double b = (y_data[end] - y_data[start]) / dt - dt * (2*yddot_data[start] + yddot_data[end]) / 6;
+
+    spline_params_.emplace_back(a,b,c,d);
+  }
+}
+
+double descartes_utilities::SplineInterpolator::position(double x) const
+{
+  unsigned idx = this->search(x);
+  return spline_params_[idx].position(x - x_data_[idx]);
+}
+
+double descartes_utilities::SplineInterpolator::velocity(double x) const
+{
+  unsigned idx = this->search(x);
+  return spline_params_[idx].velocity(x - x_data_[idx]);
+}
+
+double descartes_utilities::SplineInterpolator::acceleration(double x) const
+{
+  unsigned idx = this->search(x);
+  return spline_params_[idx].acceleration(x - x_data_[idx]);
+}
+
+std::pair<double, unsigned> descartes_utilities::SplineInterpolator::maxVelocity() const
+{
+  unsigned idx = 0;
+  double max = 0.0;
+
+  for (unsigned i = 0; i < spline_params_.size(); ++i)
+  {
+    double vel = maxSegmentVelocity(i);
+    if (vel > max)
+    {
+      max = vel;
+      idx = i;
+    }
+  }
+  return {max, idx};
+}
+
+std::pair<double, unsigned> descartes_utilities::SplineInterpolator::maxAcceleration() const
+{
+  unsigned idx = 0;
+  double max = 0.0;
+
+  for (unsigned i = 0; i < spline_params_.size(); ++i)
+  {
+    double acc = maxSegmentAcceleration(i);
+    if (acc > max)
+    {
+      max = acc;
+      idx = i;
+    }
+  }
+  return {max, idx};
+}
+
+unsigned descartes_utilities::SplineInterpolator::search(double x) const
+{
+  if (x <= x_data_.front()) return 0u;
+  if (x >= x_data_.back()) return x_data_.size() - 2u;
+
+  auto it = std::lower_bound(x_data_.begin(), x_data_.end(), x); // first point not less than x
+  return std::distance(x_data_.begin(), it) - 1; // We want the previous point
+}
+
+double descartes_utilities::SplineInterpolator::maxSegmentVelocity(unsigned idx) const
+{
+  const auto x = spline_params_[idx].xMaxVelocity();
+  const auto start_x = x_data_[idx];
+  const auto stop_x = x_data_[idx+1];
+
+  if (x > 0 && x < stop_x - start_x)
+  {
+    return spline_params_[idx].velocity(x);
+  }
+  else
+  {
+    const auto start_v = std::abs(spline_params_[idx].velocity(0.0));
+    const auto stop_v = std::abs(spline_params_[idx].velocity(stop_x - start_x));
+    return std::max(start_v, stop_v);
+  }
+}
+
+double descartes_utilities::SplineInterpolator::maxSegmentAcceleration(unsigned idx) const
+{
+  const auto x = spline_params_[idx].xMaxAcceleration();
+  const auto start_x = x_data_[idx];
+  const auto stop_x = x_data_[idx+1];
+
+  if (x > 0 && x < stop_x - start_x)
+  {
+    return spline_params_[idx].acceleration(x);
+  }
+  else
+  {
+    const auto start_a = std::abs(spline_params_[idx].acceleration(0.0));
+    const auto stop_a = std::abs(spline_params_[idx].acceleration(stop_x - start_x));
+    return std::max(start_a, stop_a);
+  }
+}

--- a/descartes_utilities/src/spline_tests.cpp
+++ b/descartes_utilities/src/spline_tests.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+
+#include "descartes_utilities/spline_interpolator.h"
+#include "descartes_utilities/ros_conversions.h"
+
+#include <fstream>
+
+int main()
+{
+  // using namespace trajectory_msgs;
+  // std::vector<JointTrajectoryPoint> points;
+
+  // for (std::size_t i = 0; i < 10; i++)
+  // {
+  //   auto pt = JointTrajectoryPoint();
+  //   pt.positions.resize(6, i / 10.0);
+  //   pt.time_from_start = ros::Duration(i);
+  //   points.push_back(pt);
+  // }
+
+  // if (descartes_utilities::parameterizeVelocityAcceleration(points))
+  // {
+  //   std::cout << "It worked\n";
+
+  //   std::ofstream j1 ("j1.csv");
+  //   std::ofstream j2 ("j2.csv");
+  //   std::ofstream j3 ("j3.csv");
+  //   std::ofstream j4 ("j4.csv");
+  //   std::ofstream j5 ("j5.csv");
+  //   std::ofstream j6 ("j6.csv");
+
+  //   for (auto&& point : points)
+  //   {
+  //     auto tm = point.time_from_start.toSec();
+  //     j1 << tm << ",";
+  //     j2 << tm << ",";
+  //     j3 << tm << ",";
+  //     j4 << tm << ",";
+  //     j5 << tm << ",";
+  //     j6 << tm << ",";
+
+  //     j1 << point.positions[0] << "," << point.velocities[0] << "," << point.accelerations[0] << "\n";
+  //     j2 << point.positions[1] << "," << point.velocities[1] << "," << point.accelerations[1] << "\n";
+  //     j3 << point.positions[2] << "," << point.velocities[2] << "," << point.accelerations[2] << "\n";
+  //     j4 << point.positions[3] << "," << point.velocities[3] << "," << point.accelerations[3] << "\n";
+  //     j5 << point.positions[4] << "," << point.velocities[4] << "," << point.accelerations[4] << "\n";
+  //     j6 << point.positions[5] << "," << point.velocities[5] << "," << point.accelerations[5] << "\n";
+  //   }
+
+  //   std::cout << "Ji: " << points.front().positions[0] << " " << points.front().velocities[0] << " " << points.front().accelerations[0] << "\n";
+  //   std::cout << "Jf: " << points.back().positions[0] << " " << points.back().velocities[0] << " " << points.back().accelerations[0] << "\n";
+  // }
+  // else
+  // {
+  //   std::cout << "It did not work\n";
+  // }
+
+
+  
+  std::vector<double> x = {0,1,2,3,4,5,6,7,8,9,10};
+  std::vector<double> y = {0,1,2,3,4,6,3, 1, -1, -2, 3};
+
+  descartes_utilities::SplineInterpolator spline (x, y, 0.0, 0.0);
+
+  std::ofstream of ("test.csv");
+
+  for (double x = 0.0; x < 10.1; x += 0.1)
+  {
+    of << x << "," << spline.position(x) 
+       << "," << spline.velocity(x) << "," << spline.acceleration(x) << "\n";
+  }
+
+  auto max_vel = spline.maxVelocity();
+  auto max_acc = spline.maxAcceleration();
+
+  std::cout << "Spline segments: " << spline.splineParams().size() << "\n";
+
+  std::cout << "Max velocity: " << max_vel.first << " at " << max_vel.second << '\n';
+  std::cout << "Max accleration: " << max_acc.first << " at " << max_acc.second << '\n';
+  
+}

--- a/descartes_utilities/test/parameterization_tests.cpp
+++ b/descartes_utilities/test/parameterization_tests.cpp
@@ -1,0 +1,61 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  parameterization_tests.cpp
+ *
+ *  Created on: March 28, 2016
+ *  Author: Jonathan Meyer
+ */
+
+#include <gtest/gtest.h>
+
+#include "descartes_utilities/parameterization.h"
+
+TEST(toCubicSplines, maintainsPositions)
+{
+  std::vector<trajectory_msgs::JointTrajectoryPoint> traj;
+
+  const auto dof = 6; // traj width (num joints)
+  const auto n = 10; // traj length
+
+  // Build trajectory
+  for (auto i = 0; i < n; ++i)
+  {
+    trajectory_msgs::JointTrajectoryPoint pt;
+    pt.time_from_start = ros::Duration(i);
+    pt.positions.resize(dof, i);
+    traj.push_back(pt);
+  }
+
+  // Compute splines
+  std::vector<descartes_utilities::SplineInterpolator> splines;
+  ASSERT_TRUE(toCubicSplines(traj, splines));
+  ASSERT_TRUE(splines.size() == dof);
+
+  // Now we test the control points for each joint and position
+  for (auto& pt : traj)
+  {
+    auto tm = pt.time_from_start.toSec();
+    for (auto i = 0; i < dof; ++i)
+    {
+      auto interpolated_position = splines[i].position(tm);
+      auto input_position = pt.positions[i];
+      EXPECT_DOUBLE_EQ(interpolated_position, input_position);  
+    }
+  }
+}

--- a/descartes_utilities/test/utest.cpp
+++ b/descartes_utilities/test/utest.cpp
@@ -1,0 +1,25 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR addresses #148. It creates a `SplineInterpolator` class that fits natural cubic splines of the form `a + bx + cx^2 + dx^3` to each pair of subsequent points.

New utility functions are now available in `parameterization.h`. These allow a user to build a set of splines from an input ROS trajectory, or simply parametrize a ROS trajectory from its `positions` and `time_from_start` fields.

The spline class also enables checking for maximum velocity and acceleration in the entire path.

I need to do some physical testing to make sure this produces desirable results, and I will update this PR when I have done that.

Furthermore, I'm curious for input on:
1. The interfaces in `parameterization.h`
2. Error handling. Currently all of the building is done in the constructor of `SplineInterpolator` but this could fail if the user provides invalid input. The utility functions check for these failure points, but anyone using the class directly may find issues. I added asserts to check for debug builds. I know there will be resistance here, but can anyone think of an elegant way to handle this without resorting to an `init` function? I'm hesistant to use exceptions because nothing else in Descartes does so.
