### PR TITLE
Expose Planning Graph through Dense Planner

### DIFF
--- a/descartes_planner/include/descartes_planner/dense_planner.h
+++ b/descartes_planner/include/descartes_planner/dense_planner.h
@@ -33,6 +33,13 @@ public:
   virtual int getErrorCode() const;
   virtual bool getErrorMessage(int error_code, std::string& msg) const;
 
+  // Helper functions meant to access the underlying graph structure
+  
+  const PlanningGraph& getPlanningGraph() const
+  {
+    return *planning_graph_;
+  }
+
 protected:
 
   descartes_core::TrajectoryPt::ID getPrevious(const descartes_core::TrajectoryPt::ID& ref_id);

--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -101,8 +101,6 @@ public:
 
   bool removeTrajectory(descartes_core::TrajectoryPtPtr point);
 
-  CartesianMap getCartesianMap() const;
-
   bool getCartesianTrajectory(std::vector<descartes_core::TrajectoryPtPtr>& traj);
 
   /** @brief Calculate and return the shortest path from the given joint solution indices
@@ -124,6 +122,14 @@ public:
   void printMaps();
 
   descartes_core::RobotModelConstPtr getRobotModel();
+
+
+  CartesianMap getCartesianMap() const;
+
+  const JointMap& getJointMap() const;
+
+  const JointGraph& getGraph() const; 
+
 
 protected:
   descartes_core::RobotModelConstPtr robot_model_;

--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -53,8 +53,21 @@ PlanningGraph::~PlanningGraph()
 
 CartesianMap PlanningGraph::getCartesianMap() const
 {
-  if (!cartesian_point_link_) return CartesianMap();
+  if (!cartesian_point_link_)
+  {
+    return CartesianMap();
+  }
   else return *cartesian_point_link_;
+}
+
+const JointMap& PlanningGraph::getJointMap() const
+{
+  return joint_solutions_map_;
+}
+
+const JointGraph& PlanningGraph::getGraph() const
+{
+  return dg_;
 }
 
 descartes_core::RobotModelConstPtr PlanningGraph::getRobotModel()


### PR DESCRIPTION
This PR is meant to provide users who explicitly use DensePlanner to access the underlying boost graph of positions and edges.

@shaun-edwards please review.
