### PR TITLE
IKFast Moveit State Adapter

### DIFF
--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(descartes_moveit
             src/moveit_state_adapter.cpp
             src/plugin_init.cpp
             src/seed_search.cpp
+            src/ikfast_moveit_state_adapter.cpp
 )
 target_link_libraries(descartes_moveit
                       ${catkin_LIBRARIES}

--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -1,0 +1,38 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Jonathan Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IKFAST_MOVEIT_STATE_ADAPTER_H
+#define IKFAST_MOVEIT_STATE_ADAPTER_H
+
+#include "descartes_moveit/moveit_state_adapter.h"
+
+namespace descartes_moveit
+{
+
+class IkFastMoveitStateAdapter : public descartes_moveit::MoveitStateAdapter
+{
+public:
+  virtual ~IkFastMoveitStateAdapter() {}
+
+  virtual bool getAllIK(const Eigen::Affine3d &pose, 
+                        std::vector<std::vector<double> > &joint_poses) const;
+
+};
+
+} // end namespace 'descartes_moveit'
+#endif

--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -29,9 +29,33 @@ class IkFastMoveitStateAdapter : public descartes_moveit::MoveitStateAdapter
 public:
   virtual ~IkFastMoveitStateAdapter() {}
 
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
+                          const std::string& world_frame, const std::string& tcp_frame);
+  
   virtual bool getAllIK(const Eigen::Affine3d &pose, 
-                        std::vector<std::vector<double> > &joint_poses) const;
+                        std::vector<std::vector<double> >& joint_poses) const;
 
+  virtual bool getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state,
+                     std::vector<double>& joint_pose) const;
+
+  virtual bool getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const;
+
+protected:
+
+  /**
+   * The IKFast implementation commonly solves between 'base_link' of a robot
+   * and 'tool0'. We will commonly want to take advantage of an additional
+   * fixed transformation from the robot flange, 'tool0', to some user defined
+   * tool. This prevents the user from having to manually adjust tool poses to
+   * account for this.
+   */
+  descartes_core::Frame tool0_to_tip_;
+
+  /**
+   * Likewise this parameter is used to accomodate transformations between the base
+   * of the IKFast solver and the base of the MoveIt move group.
+   */
+  descartes_core::Frame world_to_base_;
 };
 
 } // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-#ifndef MOVEIT_STATE_ADPATER_H_
-#define MOVEIT_STATE_ADPATER_H_
+#ifndef MOVEIT_STATE_ADAPTER_H_
+#define MOVEIT_STATE_ADAPTER_H_
 
 #include "descartes_core/robot_model.h"
 #include "descartes_trajectory/cart_trajectory_pt.h"
-#include <moveit/robot_model_loader/robot_model_loader.h>
-#include "moveit/robot_model/robot_model.h"
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
 #include <string>
 
 namespace descartes_moveit
@@ -143,4 +143,4 @@ protected:
 
 } //descartes_moveit
 
-#endif /* MOVEIT_STATE_ADPATER_H_ */
+#endif /* MOVEIT_STATE_ADAPTER_H_ */

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -20,42 +20,26 @@
 #define MOVEIT_STATE_ADPATER_H_
 
 #include "descartes_core/robot_model.h"
-#include <descartes_trajectory/cart_trajectory_pt.h>
+#include "descartes_trajectory/cart_trajectory_pt.h"
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include "moveit/robot_model/robot_model.h"
-#include "moveit/kinematics_base/kinematics_base.h"
 #include <moveit/planning_scene/planning_scene.h>
 #include <string>
 
 namespace descartes_moveit
 {
-
-/**@brief MoveitStateAdapter adapts the MoveIt RobotState to the Descartes RobotModel interface
- *
+/**
+ * @brief MoveitStateAdapter adapts the MoveIt RobotState to the Descartes RobotModel interface
  */
 class MoveitStateAdapter : public descartes_core::RobotModel
 {
-
-
 public:
   MoveitStateAdapter();
 
-  /**
-   * Constructor for Moveit state adapters (implements Descartes robot model interface)
-   * @param robot_state robot state object utilized for kinematic/dynamic state checking
-   * @param group_name planning group name
-   * @param tool_frame tool frame name
-   * @param world_frame work object frame name
-   */
-  MoveitStateAdapter(const moveit::core::RobotState & robot_state, const std::string & group_name,
-                     const std::string & tool_frame, const std::string & world_frame);
-
-  virtual ~MoveitStateAdapter()
-  {
-  }
+  virtual ~MoveitStateAdapter() {}
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& world_frame,const std::string& tcp_frame);
+                          const std::string& world_frame, const std::string& tcp_frame);
 
   virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const;
@@ -70,6 +54,9 @@ public:
 
   virtual int getDOF() const;
 
+  virtual bool isValidMove(const std::vector<double>& from_joint_pose, 
+                           const std::vector<double>& to_joint_pose,
+                           double dt) const;
   /**
    * @brief Set the initial states used for iterative inverse kineamtics
    * @param seeds Vector of vector of doubles representing joint positions.
@@ -96,12 +83,7 @@ public:
     return robot_state_;
   }
 
-  virtual bool isValidMove(const std::vector<double>& from_joint_pose, 
-                           const std::vector<double>& to_joint_pose,
-                           double dt) const;
-
 protected:
-
   /**
    * Gets IK solution (assumes robot state is pre-seeded)
    * @param pose Affine pose of TOOL in WOBJ frame
@@ -111,22 +93,27 @@ protected:
   bool getIK(const Eigen::Affine3d &pose, std::vector<double> &joint_pose) const;
 
   /**
-   * @brief Pointer to moveit robot state (mutable object state is reset with
-   * each function call
-   */
-
-  /**
    * TODO: Checks for collisions at this joint pose. The setCollisionCheck(true) must have been
    * called previously in order to enable collision checks, otherwise it will return false.
    * @param joint_pose the joint values at which check for collisions will be made
    */
   bool isInCollision(const std::vector<double> &joint_pose) const;
 
+  /**
+   * Maximum joint velocities (rad/s) for each joint in the chain. Used for checking in
+   * `isValidMove()`
+   */
   std::vector<double> velocity_limits_;
+  
   mutable moveit::core::RobotStatePtr robot_state_;
+  
   planning_scene::PlanningScenePtr planning_scene_;
-  robot_model_loader::RobotModelLoaderPtr  robot_model_loader_;
+  
   robot_model::RobotModelConstPtr robot_model_ptr_;
+
+  robot_model_loader::RobotModelLoaderPtr  robot_model_loader_;
+
+  const moveit::core::JointModelGroup* joint_group_;
 
   /**
    * @brief Vector of starting configurations for the numerical solver
@@ -152,7 +139,6 @@ protected:
    * @brief convenient transformation frame
    */
   descartes_core::Frame world_to_root_;
-
 };
 
 } //descartes_moveit

--- a/descartes_moveit/moveit_adapter_plugins.xml
+++ b/descartes_moveit/moveit_adapter_plugins.xml
@@ -3,4 +3,7 @@
   <class name="descartes_moveit/MoveitStateAdapter" type="descartes_moveit::MoveitStateAdapter" base_class_type="descartes_core::RobotModel">
     <description>This is a robot model adapter for descartes</description>
   </class>
+  <class name="descartes_moveit/IkFastMoveitStateAdapter" type="descartes_moveit::IkFastMoveitStateAdapter" base_class_type="descartes_core::RobotModel">
+    <description>This is a robot model adapter for descartes when using a MoveIt-IKFast plugin</description>
+  </class>
 </library>

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -1,0 +1,52 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016, Jonathan Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "descartes_moveit/ikfast_moveit_state_adapter.h"
+#include "eigen_conversions/eigen_msg.h"
+
+bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d &pose, 
+  std::vector<std::vector<double> > &joint_poses) const
+{
+  joint_poses.clear();
+  const auto& solver = joint_group_->getSolverInstance();
+
+  // Transform input pose
+  Eigen::Affine3d tool_pose = world_to_root_.frame * pose;
+
+  // convert to geometry_msgs ...
+  geometry_msgs::Pose geometry_pose;
+  tf::poseEigenToMsg(tool_pose, geometry_pose);
+  std::vector<geometry_msgs::Pose> poses = {geometry_pose};
+
+  std::vector<double> dummy_seed (getDOF(), 0.0);
+  std::vector<std::vector<double>> joint_results;
+  kinematics::KinematicsResult result;
+  kinematics::KinematicsQueryOptions options; // defaults are reasonable as of Indigo
+
+  if (!solver->getPositionIK(poses, dummy_seed, joint_results, result, options))
+  {
+    return false;
+  }
+
+  for (auto& sol : joint_results)
+  {
+    if (isValid(sol)) joint_poses.push_back(std::move(sol));
+  }
+
+  return joint_poses.size() > 0;
+}

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -17,7 +17,67 @@
  */
 
 #include "descartes_moveit/ikfast_moveit_state_adapter.h"
-#include "eigen_conversions/eigen_msg.h"
+
+#include <cassert>
+#include <eigen_conversions/eigen_msg.h>
+#include <ros/node_handle.h>
+
+const static std::string default_base_frame = "base_link";
+const static std::string default_tool_frame = "tool0";
+
+// Compute the 'joint distance' between two poses
+static double distance(const std::vector<double>& a, const std::vector<double>& b)
+{
+  double cost = 0.0;
+  for (size_t i = 0; i < a.size(); ++i)
+    cost += std::abs(b[i] - a[i]);
+  return cost;
+}
+
+// Compute the index of the closest joint pose in 'candidates' from 'target'
+static size_t closestJointPose(const std::vector<double>& target, 
+                               const std::vector<std::vector<double>>& candidates)
+{
+  size_t closest = 0; // index into candidates
+  double lowest_cost = std::numeric_limits<double>::max();
+  for (size_t i = 0; i < candidates.size(); ++i)
+  {
+    assert(target.size() == candidates[i].size());
+    double c = distance(target, candidates[i]);
+    if (c < lowest_cost)
+    {
+      closest = i;
+      lowest_cost = c;
+    }
+  }
+  return closest;
+}
+
+bool descartes_moveit::IkFastMoveitStateAdapter::initialize(const std::string& robot_description, const std::string& group_name,
+                                                            const std::string& world_frame, const std::string& tcp_frame)
+{
+  if (!MoveitStateAdapter::initialize(robot_description, group_name, world_frame, tcp_frame))
+  {
+    return false;
+  }
+  // move group tip frame that we want to solve in
+  const auto& tip_frame = joint_group_->getSolverInstance()->getTipFrame();
+  // look up the IKFast base and tool frame
+  ros::NodeHandle nh;
+  std::string ikfast_base_frame, ikfast_tool_frame;
+  nh.param<std::string>("ikfast_base_frame", ikfast_base_frame, default_base_frame);
+  nh.param<std::string>("ikfast_tool_frame", ikfast_tool_frame, default_tool_frame);
+  // calculate frames
+  tool0_to_tip_ = descartes_core::Frame(robot_state_->getFrameTransform(tcp_frame).inverse() *
+                                        robot_state_->getFrameTransform(ikfast_tool_frame));
+
+  world_to_base_ = descartes_core::Frame(world_to_root_.frame *
+                                         robot_state_->getFrameTransform(ikfast_base_frame));
+
+  logInform("IkFastMoveitStateAdapter: initialized with IKFast tool frame '%s' and base frame '%s'.", 
+            ikfast_tool_frame.c_str(), ikfast_base_frame.c_str());
+  return true;
+}
 
 bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d &pose, 
   std::vector<std::vector<double> > &joint_poses) const
@@ -26,7 +86,7 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d 
   const auto& solver = joint_group_->getSolverInstance();
 
   // Transform input pose
-  Eigen::Affine3d tool_pose = world_to_root_.frame * pose;
+  Eigen::Affine3d tool_pose = world_to_base_.frame_inv * pose * tool0_to_tip_.frame;
 
   // convert to geometry_msgs ...
   geometry_msgs::Pose geometry_pose;
@@ -49,4 +109,32 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d 
   }
 
   return joint_poses.size() > 0;
+}
+
+
+bool descartes_moveit::IkFastMoveitStateAdapter::getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state,
+                                                       std::vector<double>& joint_pose) const
+{
+  // Descartes Robot Model interface calls for 'closest' point to seed position
+  std::vector<std::vector<double>> joint_poses;
+  if (!getAllIK(pose, joint_poses)) return false;
+  // Find closest joint pose; getAllIK() does isValid checks already
+  joint_pose = joint_poses[closestJointPose(seed_state, joint_poses)];
+  return true;
+}
+
+bool descartes_moveit::IkFastMoveitStateAdapter::getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const
+{
+  const auto& solver = joint_group_->getSolverInstance();
+
+  std::vector<std::string> tip_frame = { solver->getTipFrame() };
+  std::vector<geometry_msgs::Pose> output;
+
+  if (!isValid(joint_pose)) return false;
+
+  if (!solver->getPositionFK(tip_frame, joint_pose, output)) return false;
+
+  tf::poseMsgToEigen(output[0], pose); // pose in frame of IkFast base
+  pose = world_to_base_.frame * pose * tool0_to_tip_.frame_inv;
+  return true;
 }

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -67,6 +67,21 @@ bool descartes_moveit::IkFastMoveitStateAdapter::initialize(const std::string& r
   std::string ikfast_base_frame, ikfast_tool_frame;
   nh.param<std::string>("ikfast_base_frame", ikfast_base_frame, default_base_frame);
   nh.param<std::string>("ikfast_tool_frame", ikfast_tool_frame, default_tool_frame);
+  
+  if (!robot_state_->knowsFrameTransform(ikfast_base_frame))
+  {
+    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
+             ikfast_base_frame.c_str(), group_name.c_str());
+    return false;
+  }
+
+  if (!robot_state_->knowsFrameTransform(ikfast_tool_frame))
+  {
+    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
+             ikfast_tool_frame.c_str(), group_name.c_str());
+    return false;
+  }
+
   // calculate frames
   tool0_to_tip_ = descartes_core::Frame(robot_state_->getFrameTransform(tcp_frame).inverse() *
                                         robot_state_->getFrameTransform(ikfast_tool_frame));

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -22,8 +22,8 @@
 #include "descartes_core/pretty_print.hpp"
 #include "descartes_moveit/seed_search.h"
 
-#include "eigen_conversions/eigen_msg.h"
-#include "random_numbers/random_numbers.h"
+#include <eigen_conversions/eigen_msg.h>
+#include <random_numbers/random_numbers.h>
 #include <sstream>
 
 const static int SAMPLE_ITERATIONS = 10;
@@ -332,7 +332,7 @@ bool MoveitStateAdapter::isValidMove(const std::vector<double>& from_joint_pose,
   // Check for equal sized arrays
   if (from_joint_pose.size() != to_joint_pose.size())
   {
-    ROS_ERROR_STREAM("To and From joint poses are of different sizes.");
+    logError("To and From joint poses are of different sizes.");
     return false;
   }
 

--- a/descartes_moveit/src/plugin_init.cpp
+++ b/descartes_moveit/src/plugin_init.cpp
@@ -4,5 +4,7 @@
  *********************************************************************/
 #include <pluginlib/class_list_macros.h>
 #include <descartes_moveit/moveit_state_adapter.h>
+#include <descartes_moveit/ikfast_moveit_state_adapter.h>
 
 PLUGINLIB_EXPORT_CLASS(descartes_moveit::MoveitStateAdapter, descartes_core::RobotModel)
+PLUGINLIB_EXPORT_CLASS(descartes_moveit::IkFastMoveitStateAdapter, descartes_core::RobotModel)


### PR DESCRIPTION
See #124 for all the recent hoopla. 

This PR introduces a new class: `IkFastMoveitStateAdapter` that provides a specialization of `getAllIK()` to call the new method that @jrgnicho got put into both moveit's kinematics plugin and the MoveIt Ikfast adapter (with some work remaining to be done). 

I also took the opportunity to do a bit of cleanup in the primary MoveitStateAdapter. The biggest change is that I removed the non-default constructor. It duplicated all of the code in the initialize function and added more complexity than was necessary.

Note that on Indigo this will not be useful until [this](https://github.com/ros-planning/moveit_ikfast/pull/57) PR has been approved. It should work fine on Jade. We'll probably have to rebuild most of the existing IKFast plugins if that hasn't been done already.

I have tested on my own motoman SIA20D model. I'll try and build/recompile a few extra models.
