### PR TITLE
moveit_state_adapter: fix velocity/acceleration setting for robots with passive joints

### DIFF
--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -321,8 +321,15 @@ bool MoveitStateAdapter::isValid(const std::vector<double> &joint_pose) const
     robot_state_->setJointGroupPositions(group_name_, joint_pose);
     //TODO: At some point velocities and accelerations should be set for the group as
     //well.
-    robot_state_->setVariableVelocities(std::vector<double>(joint_pose.size(), 0.));
-    robot_state_->setVariableAccelerations(std::vector<double>(joint_pose.size(), 0.));
+
+    const std::vector<std::string> active_joint_names = robot_state_->getJointModelGroup(group_name_)
+                                                        ->getActiveJointModelNames();
+    std::map<std::string, double> joint_vel_accel_map;
+    for (size_t i = 0; i < active_joint_names.size(); ++i) {
+      joint_vel_accel_map.insert(std::pair<std::string, double>(active_joint_names[i], 0.));
+    }
+    robot_state_->setVariableVelocities(joint_vel_accel_map);
+    robot_state_->setVariableAccelerations(joint_vel_accel_map);
     if (robot_state_->satisfiesBounds())
     {
       rtn = true;


### PR DESCRIPTION
Hi,
my robot has 6 active and 5 passive joints. When executing the `descartes_tutorial` example, I got an error caused in this [line](https://github.com/ros-planning/moveit_core/blob/7a8fc418268173bf25b6a979784068f3d3f241e1/robot_state/include/moveit/robot_state/robot_state.h#L244). 
The problem is, that `setVariableVelocities(const std::vector<double> &velocity)` expects the size of the `velocity` vector to >= the size of joints of the robot_model (which includes the passive joints apparently). Same yields for `setVariableAccelerations(...)`.

This PR fixes this issue by setting the velocities/accelerations for only the active joints, using `void setVariableVelocities(const std::map<std::string, double> &variable_map)`
