### PR TITLE
MoveIt-State-Adapter RobotState handling improvements

### DIFF
--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -40,7 +40,15 @@ public:
 
   virtual bool getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const;
 
+  /**
+   * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,
+   * it also recomputes the transformations to/from the IKFast reference frames.
+   */
+  void setState(const moveit::core::RobotState& state);
+
 protected:
+
+  bool computeIKFastTransforms();
 
   /**
    * The IKFast implementation commonly solves between 'base_link' of a robot

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -83,6 +83,17 @@ public:
     return robot_state_;
   }
 
+  /**
+   * @brief Copies the internal state of 'state' into this model. Useful for initializing the
+   *        value of joints that are not part of the active move group. Should be called after
+   *        'initialize()'.
+   */
+  void setState(const moveit::core::RobotState& state)
+  {
+    assert(static_cast<bool>(robot_state_));
+    *robot_state_ = state;
+  }
+
 protected:
   /**
    * Gets IK solution (assumes robot state is pre-seeded)

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -88,11 +88,7 @@ public:
    *        value of joints that are not part of the active move group. Should be called after
    *        'initialize()'.
    */
-  void setState(const moveit::core::RobotState& state)
-  {
-    assert(static_cast<bool>(robot_state_));
-    *robot_state_ = state;
-  }
+  void setState(const moveit::core::RobotState& state);
 
 protected:
   /**

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -125,8 +125,7 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getFK(const std::vector<double>
 
 void descartes_moveit::IkFastMoveitStateAdapter::setState(const moveit::core::RobotState& state)
 {
-  ROS_ASSERT_MSG(static_cast<bool>(robot_state_), "'robot_state_' member pointer is null. Have you called initialize()?");
-  *robot_state_ = state;
+  descartes_moveit::MoveitStateAdapter::setState(state);
   computeIKFastTransforms();
 }
 

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -60,38 +60,8 @@ bool descartes_moveit::IkFastMoveitStateAdapter::initialize(const std::string& r
   {
     return false;
   }
-  // move group tip frame that we want to solve in
-  const auto& tip_frame = joint_group_->getSolverInstance()->getTipFrame();
-  // look up the IKFast base and tool frame
-  ros::NodeHandle nh;
-  std::string ikfast_base_frame, ikfast_tool_frame;
-  nh.param<std::string>("ikfast_base_frame", ikfast_base_frame, default_base_frame);
-  nh.param<std::string>("ikfast_tool_frame", ikfast_tool_frame, default_tool_frame);
-  
-  if (!robot_state_->knowsFrameTransform(ikfast_base_frame))
-  {
-    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
-             ikfast_base_frame.c_str(), group_name.c_str());
-    return false;
-  }
 
-  if (!robot_state_->knowsFrameTransform(ikfast_tool_frame))
-  {
-    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
-             ikfast_tool_frame.c_str(), group_name.c_str());
-    return false;
-  }
-
-  // calculate frames
-  tool0_to_tip_ = descartes_core::Frame(robot_state_->getFrameTransform(tcp_frame).inverse() *
-                                        robot_state_->getFrameTransform(ikfast_tool_frame));
-
-  world_to_base_ = descartes_core::Frame(world_to_root_.frame *
-                                         robot_state_->getFrameTransform(ikfast_base_frame));
-
-  logInform("IkFastMoveitStateAdapter: initialized with IKFast tool frame '%s' and base frame '%s'.", 
-            ikfast_tool_frame.c_str(), ikfast_base_frame.c_str());
-  return true;
+  return computeIKFastTransforms();
 }
 
 bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d &pose, 
@@ -152,4 +122,44 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getFK(const std::vector<double>
   tf::poseMsgToEigen(output[0], pose); // pose in frame of IkFast base
   pose = world_to_base_.frame * pose * tool0_to_tip_.frame_inv;
   return true;
+}
+
+void descartes_moveit::IkFastMoveitStateAdapter::setState(const moveit::core::RobotState& state)
+{
+  assert(static_cast<bool>(robot_state_));
+  *robot_state_ = state;
+  computeIKFastTransforms();
+}
+
+bool descartes_moveit::IkFastMoveitStateAdapter::computeIKFastTransforms()
+{
+  // look up the IKFast base and tool frame
+  ros::NodeHandle nh;
+  std::string ikfast_base_frame, ikfast_tool_frame;
+  nh.param<std::string>("ikfast_base_frame", ikfast_base_frame, default_base_frame);
+  nh.param<std::string>("ikfast_tool_frame", ikfast_tool_frame, default_tool_frame);
+
+  if (!robot_state_->knowsFrameTransform(ikfast_base_frame))
+  {
+    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
+             ikfast_base_frame.c_str(), group_name_.c_str());
+    return false;
+  }
+
+  if (!robot_state_->knowsFrameTransform(ikfast_tool_frame))
+  {
+    logError("IkFastMoveitStateAdapter: Cannot find transformation to frame '%s' in group '%s'.",
+             ikfast_tool_frame.c_str(), group_name_.c_str());
+    return false;
+  }
+
+  // calculate frames
+  tool0_to_tip_ = descartes_core::Frame(robot_state_->getFrameTransform(tool_frame_).inverse() *
+                                        robot_state_->getFrameTransform(ikfast_tool_frame));
+
+  world_to_base_ = descartes_core::Frame(world_to_root_.frame *
+                                         robot_state_->getFrameTransform(ikfast_base_frame));
+
+  logInform("IkFastMoveitStateAdapter: initialized with IKFast tool frame '%s' and base frame '%s'.",
+            ikfast_tool_frame.c_str(), ikfast_base_frame.c_str());
 }

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -18,7 +18,6 @@
 
 #include "descartes_moveit/ikfast_moveit_state_adapter.h"
 
-#include <cassert>
 #include <eigen_conversions/eigen_msg.h>
 #include <ros/node_handle.h>
 
@@ -126,7 +125,7 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getFK(const std::vector<double>
 
 void descartes_moveit::IkFastMoveitStateAdapter::setState(const moveit::core::RobotState& state)
 {
-  assert(static_cast<bool>(robot_state_));
+  ROS_ASSERT_MSG(static_cast<bool>(robot_state_), "'robot_state_' member pointer is null. Have you called initialize()?");
   *robot_state_ = state;
   computeIKFastTransforms();
 }

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -24,6 +24,7 @@
 
 #include <eigen_conversions/eigen_msg.h>
 #include <random_numbers/random_numbers.h>
+#include <ros/assert.h>
 #include <sstream>
 
 const static int SAMPLE_ITERATIONS = 10;
@@ -77,6 +78,7 @@ bool MoveitStateAdapter::initialize(const std::string& robot_description,
   robot_model_loader_.reset(new robot_model_loader::RobotModelLoader(robot_description));
   robot_model_ptr_ = robot_model_loader_->getModel();
   robot_state_.reset(new moveit::core::RobotState(robot_model_ptr_));
+  robot_state_->setToDefaultValues();
   planning_scene_.reset(new planning_scene::PlanningScene(robot_model_loader_->getModel()));
   joint_group_ = robot_model_ptr_->getJointModelGroup(group_name);
   
@@ -325,6 +327,12 @@ bool MoveitStateAdapter::isValidMove(const std::vector<double>& from_joint_pose,
   }
 
   return true;
+}
+
+void MoveitStateAdapter::setState(const moveit::core::RobotState& state)
+{
+  ROS_ASSERT_MSG(static_cast<bool>(robot_state_), "'robot_state_' member pointer is null. Have you called initialize()?");
+  *robot_state_ = state;
 }
 
 } //descartes_moveit

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -333,6 +333,7 @@ void MoveitStateAdapter::setState(const moveit::core::RobotState& state)
 {
   ROS_ASSERT_MSG(static_cast<bool>(robot_state_), "'robot_state_' member pointer is null. Have you called initialize()?");
   *robot_state_ = state;
+  planning_scene_->setCurrentState(state);
 }
 
 } //descartes_moveit


### PR DESCRIPTION
Related to #161, #130.

This PR:
1. Removes checks on accelerations/velocities that do not currently serve a purpose
2. Refactors the `isValid` function to hopefully work with a wider range of MoveIt robots (e.g. those that have passive joints or extra joints not in the move-group being planned for).
3. Adds a `setState` function to the two moveit robot models that allows a user to set the initial state for the planner. This enables a user to plan with robots that have additional joints before the desired planning group. You could, for example, set the position of a rail, get the proper transforms, and then plan for the 6 DOF robot ontop.

No performance regressions (in fact a small improvement), and the basic tests and robot models I have work.

I'll come up with some extras to test.
