### PR TITLE
Speed up search of planning graph

### DIFF
--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -664,6 +664,9 @@ bool PlanningGraph::getShortestPath(double& cost, std::list<JointTrajectoryPt>& 
   // through the graph
   cost = std::numeric_limits<double>::max();
 
+  // Remember which lowest cost end point should be used to create the solution path
+  JointGraph::vertex_descriptor cheapest_end_point;
+
   // initialize vectors to be used by dijkstra
   std::vector<JointGraph::vertex_descriptor> predecessors(num_vert);
   std::vector<double> weights(num_vert, std::numeric_limits<double>::max());
@@ -683,17 +686,18 @@ bool PlanningGraph::getShortestPath(double& cost, std::list<JointTrajectoryPt>& 
     if (weight < cost)
     {
       cost = weight;
-      path.clear();
-      // Add the destination point.
-      auto current = *end;
-      // Starting from the destination point step through the predecessor map
-      // until the source point is reached.
-      while (current != virtual_vertex)
-      {
-        path.push_front(joint_solutions_map_[vertex_index_map[current]]);
-        current = predecessors[current];
-      }
+      cheapest_end_point = *end;
     }
+  }
+
+  // Create the solution path with the lowest-cost endpoint
+  path.clear();
+  auto current = cheapest_end_point;
+  // Starting from the destination point step through the predecessor map until the source point is reached.
+  while (current != virtual_vertex)
+  {
+    path.push_front(joint_solutions_map_[vertex_index_map[current]]);
+    current = predecessors[current];
   }
 
   // Undo the virtual joint


### PR DESCRIPTION
While reviewing planning_graph.cpp I noticed in [getShortestPath()](https://github.com/ros-industrial-consortium/descartes/blob/indigo-devel/descartes_planner/src/planning_graph.cpp#L686) in the loop that looks for the goal ending point with the smallest cost, it is wasting some computation. In its current form it walks in reverse each best found shortest path, which in the worse case means it could have to generate a candidate solution path for every goal state. This seems like a simple fix of storing the `end_point` with the smallest weight, then afterwards creating the path.

Note I have not tested this at runtime because I'm not using this function atm.
