### PR TITLE
Made findStart/EndVertices public and const

### DIFF
--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -136,6 +136,12 @@ public:
 
   const JointGraph &getGraph() const;
 
+  /** @brief simple function to iterate over all graph vertices to find ones that do not have an incoming edge */
+  bool findStartVertices(std::vector<JointGraph::vertex_descriptor> &start_points) const;
+
+  /** @brief simple function to iterate over all graph vertices to find ones that do not have an outgoing edge */
+  bool findEndVertices(std::vector<JointGraph::vertex_descriptor> &end_points) const;
+
 protected:
   descartes_core::RobotModelConstPtr robot_model_;
 
@@ -144,7 +150,7 @@ protected:
   JointGraph dg_;
 
   int recalculateJointSolutionsVertexMap(
-      std::map<descartes_core::TrajectoryPt::ID, JointGraph::vertex_descriptor> &joint_vertex_map);
+      std::map<descartes_core::TrajectoryPt::ID, JointGraph::vertex_descriptor> &joint_vertex_map) const;
 
   /**
    * @brief A pair indicating the validity of the edge, and if valid, the cost associated
@@ -166,12 +172,6 @@ protected:
   // maintains a map of joint solutions with it's corresponding graph vertex_descriptor
   //   one or more of these will exist for each element in trajectory_point_map
   JointMap joint_solutions_map_;
-
-  /** @brief simple function to iterate over all graph vertices to find ones that do not have an incoming edge */
-  bool findStartVertices(std::vector<JointGraph::vertex_descriptor> &start_points);
-
-  /** @brief simple function to iterate over all graph vertices to find ones that do not have an outgoing edge */
-  bool findEndVertices(std::vector<JointGraph::vertex_descriptor> &end_points);
 
   /** @brief (Re)create the list of joint solutions from the given descartes_core::TrajectoryPt list */
   bool calculateJointSolutions(const std::vector<descartes_core::TrajectoryPtPtr> &points,

--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -554,7 +554,7 @@ bool PlanningGraph::removeTrajectory(TrajectoryPtPtr point)
   return true;
 }
 
-bool PlanningGraph::findStartVertices(std::vector<JointGraph::vertex_descriptor>& start_points)
+bool PlanningGraph::findStartVertices(std::vector<JointGraph::vertex_descriptor>& start_points) const
 {
   // Create local id->vertex map
   VertexMap joint_vertex_map;
@@ -593,7 +593,7 @@ bool PlanningGraph::findStartVertices(std::vector<JointGraph::vertex_descriptor>
   return !start_points.empty();
 }
 
-bool PlanningGraph::findEndVertices(std::vector<JointGraph::vertex_descriptor>& end_points)
+bool PlanningGraph::findEndVertices(std::vector<JointGraph::vertex_descriptor>& end_points) const
 {
   // Create local id->vertex map
   VertexMap joint_vertex_map;
@@ -724,7 +724,7 @@ void PlanningGraph::printMaps()
   }
 }
 
-int PlanningGraph::recalculateJointSolutionsVertexMap(VertexMap& joint_map)
+int PlanningGraph::recalculateJointSolutionsVertexMap(VertexMap& joint_map) const
 {
   std::pair<VertexIterator, VertexIterator> vi = vertices(dg_);
 


### PR DESCRIPTION
Once a Descartes planning graph is created, I need a way to get the enumerated start and goal vertices from my external program
