### PR TITLE
Ability to skip re-parsing URDF and instead pass in moveit::RobotModel

### DIFF
--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -43,6 +43,9 @@ public:
   virtual bool initialize(const std::string &robot_description, const std::string &group_name,
                           const std::string &world_frame, const std::string &tcp_frame);
 
+  virtual bool initialize(robot_model::RobotModelConstPtr robot_model, const std::string &group_name,
+                          const std::string &world_frame, const std::string &tcp_frame);
+
   virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const;
 

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -72,10 +72,17 @@ bool MoveitStateAdapter::initialize(const std::string& robot_description, const 
 {
   // Initialize MoveIt state objects
   robot_model_loader_.reset(new robot_model_loader::RobotModelLoader(robot_description));
-  robot_model_ptr_ = robot_model_loader_->getModel();
+
+  return initialize(robot_model_loader_->getModel(), group_name, world_frame, tcp_frame);
+}
+
+bool MoveitStateAdapter::initialize(robot_model::RobotModelConstPtr robot_model, const std::string &group_name,
+                                    const std::string &world_frame, const std::string &tcp_frame)
+{
+  robot_model_ptr_ = robot_model;
   robot_state_.reset(new moveit::core::RobotState(robot_model_ptr_));
   robot_state_->setToDefaultValues();
-  planning_scene_.reset(new planning_scene::PlanningScene(robot_model_loader_->getModel()));
+  planning_scene_.reset(new planning_scene::PlanningScene(robot_model));
   joint_group_ = robot_model_ptr_->getJointModelGroup(group_name);
 
   // Assign robot frames


### PR DESCRIPTION
The [roscon_2015](https://github.com/ros-industrial-consortium/roscon_2015/) demo requires the URDF to be parsed from string several times. This is slow, especially when running in debug mode or a profile. Since my application already has a loaded moveit::RobotModel, I want to just optionally pass it in. Simple.
