### PR TITLE
Fix for Boost graph never cleared between plans

### DIFF
--- a/descartes_planner/include/descartes_planner/planning_graph.h
+++ b/descartes_planner/include/descartes_planner/planning_graph.h
@@ -89,6 +89,9 @@ public:
 
   virtual ~PlanningGraph();
 
+  /** \brief Clear all previous graph data */
+  void clear();
+
   /** @brief initial population of graph trajectory elements
    * @param points list of trajectory points to be used to construct the graph
    * @return True if the graph was successfully created

--- a/descartes_planner/src/planning_graph.cpp
+++ b/descartes_planner/src/planning_graph.cpp
@@ -51,7 +51,14 @@ PlanningGraph::PlanningGraph(RobotModelConstPtr model, CostFunction cost_functio
 
 PlanningGraph::~PlanningGraph()
 {
+  clear();
+}
+
+void PlanningGraph::clear()
+{
   delete cartesian_point_link_;
+  dg_.clear();
+  joint_solutions_map_.clear();
 }
 
 CartesianMap PlanningGraph::getCartesianMap() const
@@ -94,7 +101,10 @@ bool PlanningGraph::insertGraph(const std::vector<TrajectoryPtPtr>* points)
     return false;
   }
 
-  delete cartesian_point_link_;  // remove the previous map before we start on a new one
+  // Reset any previous graph data
+  clear();
+
+  // Start new map
   cartesian_point_link_ = new std::map<TrajectoryPt::ID, CartesianPointInformation>();
 
   // DEBUG


### PR DESCRIPTION
Also centralized resetting into one function `clear()`

Before this the vertex count doubled every call.
