### PR TITLE
Added insertion directly into planning_graph w/o planning

### DIFF
--- a/descartes_core/include/descartes_core/path_planner_base.h
+++ b/descartes_core/include/descartes_core/path_planner_base.h
@@ -50,7 +50,6 @@ public:
   /**
    * @brief Plans a path for the given robot model and configuration parameters.
    * @param model robot model implementation for which to plan a path
-   * @param config A map containing the parameter/value pairs.
    */
   virtual bool initialize(RobotModelConstPtr model) = 0;
 

--- a/descartes_planner/include/descartes_planner/dense_planner.h
+++ b/descartes_planner/include/descartes_planner/dense_planner.h
@@ -26,6 +26,10 @@ public:
   virtual bool setConfig(const descartes_core::PlannerConfig& config);
   virtual void getConfig(descartes_core::PlannerConfig& config) const;
   virtual bool planPath(const std::vector<descartes_core::TrajectoryPtPtr>& traj);
+
+  /** \brief Populate a Cartesian trajectory graph, but do not solve. For use by external solvers */
+  virtual bool insertGraph(const std::vector<descartes_core::TrajectoryPtPtr>& traj);
+
   virtual bool getPath(std::vector<descartes_core::TrajectoryPtPtr>& path) const;
   virtual bool addAfter(const descartes_core::TrajectoryPt::ID& ref_id, descartes_core::TrajectoryPtPtr tp);
   virtual bool addBefore(const descartes_core::TrajectoryPt::ID& ref_id, descartes_core::TrajectoryPtPtr tp);

--- a/descartes_planner/src/dense_planner.cpp
+++ b/descartes_planner/src/dense_planner.cpp
@@ -199,7 +199,6 @@ bool DensePlanner::planPath(const std::vector<descartes_core::TrajectoryPtPtr>& 
     return false;
   }
 
-  double cost;
   path_.clear();
   error_code_ = descartes_core::PlannerError::EMPTY_PATH;
 
@@ -213,6 +212,22 @@ bool DensePlanner::planPath(const std::vector<descartes_core::TrajectoryPtPtr>& 
   }
 
   return descartes_core::PlannerError::OK == error_code_;
+}
+
+bool DensePlanner::insertGraph(const std::vector<descartes_core::TrajectoryPtPtr>& traj)
+{
+  if(error_code_ == descartes_core::PlannerError::UNINITIALIZED)
+  {
+    ROS_ERROR_STREAM("Planner has not been initialized");
+    return false;
+  }
+
+  if(!planning_graph_->insertGraph(&traj))
+  {
+    return false;
+  }
+
+  return true;
 }
 
 bool DensePlanner::getPath(std::vector<descartes_core::TrajectoryPtPtr>& path) const


### PR DESCRIPTION
This hook allows me to use Descartes to generate a graph without planning over it

Also removes invalid comment and unused variable.
