### PR TITLE
Upgrade to Eigen3 per ROS Kinetic requirements

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
@@ -31,7 +31,7 @@ catkin_package(
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${Eigen_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_library(descartes_core
@@ -47,7 +47,7 @@ target_link_libraries(descartes_core
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(rosconsole_bridge REQUIRED)
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
@@ -38,7 +38,7 @@ catkin_package(
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${Eigen_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Descartes MoveIt lib
@@ -72,7 +72,7 @@ endif()
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(

--- a/descartes_planner/CMakeLists.txt
+++ b/descartes_planner/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -38,7 +38,7 @@ catkin_package(
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${Eigen_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## DescartesTrajectoryPt lib
@@ -59,7 +59,7 @@ target_link_libraries(descartes_planner
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(
@@ -75,7 +75,7 @@ install(
 
 if(CATKIN_ENABLE_TESTING)
 
-  set(UTEST_PLANNER_SRC_FILES 
+  set(UTEST_PLANNER_SRC_FILES
       test/utest.cpp
       test/dense_planner.cpp
       test/sparse_planner.cpp

--- a/descartes_trajectory/CMakeLists.txt
+++ b/descartes_trajectory/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -36,7 +36,7 @@ catkin_package(
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${Eigen_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_library(descartes_trajectory
@@ -57,7 +57,7 @@ target_link_libraries(descartes_trajectory
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(


### PR DESCRIPTION
I'm running Descartes on Jade ([migration](http://wiki.ros.org/jade/Migration)) now and this suppresses deprecation warnings for the old Eigen. Not sure if we want to create a jade or kinetic branch instead. I'm pretty sure this is backwards compatible to indigo, but I think someone should test it
