### PR TITLE
Make isInCollision(..) use an up-to-date PlanningScene instance when checking (for Godel)

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -131,6 +131,8 @@ public:
   virtual bool isValidMove(const std::vector<double> &from_joint_pose, const std::vector<double> &to_joint_pose,
                            double dt) const = 0;
 
+  virtual bool updateInternals() const {}
+
 protected:
   RobotModel() : check_collisions_(false)
   {

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -22,6 +22,7 @@
 #include "descartes_core/robot_model.h"
 #include "descartes_trajectory/cart_trajectory_pt.h"
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <string>
@@ -61,6 +62,9 @@ public:
 
   virtual bool isValidMove(const std::vector<double> &from_joint_pose, const std::vector<double> &to_joint_pose,
                            double dt) const;
+
+  virtual bool updateInternals() const;
+
   /**
    * @brief Set the initial states used for iterative inverse kineamtics
    * @param seeds Vector of vector of doubles representing joint positions.
@@ -118,7 +122,7 @@ protected:
 
   mutable moveit::core::RobotStatePtr robot_state_;
 
-  planning_scene::PlanningScenePtr planning_scene_;
+  mutable planning_scene::PlanningScenePtr planning_scene_;
 
   robot_model::RobotModelConstPtr robot_model_ptr_;
 
@@ -150,6 +154,11 @@ protected:
    * @brief convenient transformation frame
    */
   descartes_core::Frame world_to_root_;
+
+  /**
+   * @brief Planning scene monitor (used to update internal planning scene)
+   */
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };
 
 }  // descartes_moveit

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -131,6 +131,10 @@ bool MoveitStateAdapter::initialize(robot_model::RobotModelConstPtr robot_model,
     world_to_root_ = descartes_core::Frame(root_to_world.inverse());
   }
 
+  // create monitor and immediately retrieve up-to-date planning scene copy
+  planning_scene_monitor_ = boost::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
+  updateInternals();
+
   return true;
 }
 
@@ -320,6 +324,26 @@ bool MoveitStateAdapter::isValidMove(const std::vector<double>& from_joint_pose,
     if (dtheta > max_dtheta)
       return false;
   }
+
+  return true;
+}
+
+bool MoveitStateAdapter::updateInternals() const
+{
+  logInform("updateInternals: updating internals");
+
+  planning_scene_monitor_->requestPlanningSceneState();
+  planning_scene_monitor::LockedPlanningSceneRW psm_lpsrw(planning_scene_monitor_);
+  psm_lpsrw->getCurrentStateNonConst().update();
+
+  planning_scene_ = psm_lpsrw->diff();
+  planning_scene_->decoupleParent();
+
+  logInform("updateInternals: updated");
+
+  //planning_scene_->printKnownObjects(std::cout);
+
+  logInform("updateInternals: done");
 
   return true;
 }


### PR DESCRIPTION
As per subject. This appears to be the minimum amount of changes needed to implement the described functionality.

Note that in order to avoid service invocation overhead, callers of any planner functions are required to first call `robot_model::updateInternals()`.

This PR might not be mergeable as-is, but I wanted to allow for discussion here.
