### PR TITLE
Install Space Issues and Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ notifications:
     on_failure: always
 
 env:
+  global:
+    - BEFORE_SCRIPT='catkin config -w $CATKIN_WORKSPACE --no-install'
   matrix:
     - USE_DEB=true  
       ROS_DISTRO="kinetic" 


### PR DESCRIPTION
So the `descartes_trajectory` library defines a few "helper" classes meant solely for testing. These are exported via the `catkin_package` command, but were not installed (presumably because these test artifacts don't need to be in the final product). These include a `cartesian_robot` header and class that is used in `descartes_trajectory`, `descartes_planners`, and `descartes_moveit`. 

For the moment, I'm just turning off testing in the install space. Long term though, I assume that I will need to either:
 * Make a `descartes_tests` package so the testing specific items can be isolated (and not installed).
 * Add install rules for the headers and libraries needed specifically for testing and find a way to link against them. I could simply add a `test` subfolder to each package's include directory.

@gavanderhoorn @130s Do you have any advice? What's the correct way to share headers and libraries solely meant for testing between packages?