### PR TITLE
Added a Separate Check For Joint Limits

### DIFF
--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -110,7 +110,15 @@ protected:
    * called previously in order to enable collision checks, otherwise it will return false.
    * @param joint_pose the joint values at which check for collisions will be made
    */
-  bool isInCollision(const std::vector<double> &joint_pose) const;
+  bool isInCollision(const std::vector<double>& joint_pose) const;
+
+  /**
+   * @brief Checks to see if the given joint_pose state is inside the bounds for the initialized
+   * robot model's active joints.
+   * @param joint_pose The pose to check; should be the same length as your groups active num active joints
+   * @return true if the @e joint_pose is in bounds, false otherwise
+   */
+  bool isInLimits(const std::vector<double>& joint_pose) const;
 
   /**
    * Maximum joint velocities (rad/s) for each joint in the chain. Used for checking in

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -245,6 +245,11 @@ bool MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) co
   return in_collision;
 }
 
+bool MoveitStateAdapter::isInLimits(const std::vector<double> &joint_pose) const
+{
+  return joint_group_->satisfiesPositionBounds(joint_pose.data());
+}
+
 bool MoveitStateAdapter::getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const
 {
   bool rtn = false;
@@ -282,13 +287,7 @@ bool MoveitStateAdapter::isValid(const std::vector<double>& joint_pose) const
     return false;
   }
 
-  // Satisfies joint positional bounds?
-  if (!joint_group_->satisfiesPositionBounds(joint_pose.data()))
-  {
-    return false;
-  }
-  // Is in collision (if collision is active)
-  return !isInCollision(joint_pose);
+  return isInLimits(joint_pose) && !isInCollision(joint_pose);
 }
 
 bool MoveitStateAdapter::isValid(const Eigen::Affine3d& pose) const


### PR DESCRIPTION
For the sake of efficiency, I've broken out the check for joint limits. This let's you use the following code to search redundant joints without performing redundant collision checks:

See IKFastMoveitStateAdapter's getAllIK function:
```c++

 if (!solver->getPositionIK(poses, dummy_seed, joint_results, result, options))
  {
    return false;
  }

  const auto dof = getDOF();
  const auto index6 = dof - 1;
  const auto index4 = dof - 3;

  auto search_extras = [this, &joint_poses, index6, index4](std::vector<double>& sol)
  {
    bool collision_checked = false;

    const double joint6 = sol[index6];
    const double joint4 = sol[index4];

    for (int i = -1; i <= 1; ++i)
    {
      sol[index6] = joint6 + i * 2.0 * M_PI;
      for (int j = -1; j <= 1; ++j)
      {
        sol[index4] = joint4 + j * 2.0 * M_PI;
        if (isInLimits(sol))
        {
          if (!collision_checked)
          {
            if (isInCollision(sol)) return;
            else collision_checked = true;
          }
          joint_poses.push_back(sol);
        } // in limits
      }
    }
  };

  for (auto& sol : joint_results)
  {
    search_extras(sol);
}
```

I need to figure out how to nicely integrate this into IKFastStateAdapter. I don't always want to search every joint that could be searched (all of them on a UR for example). How do we let users configure this?

Please take a look @BrettHemes. 
