### PR TITLE
Improve catkin packages thanks to catkin_lint

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -4,9 +4,9 @@ project(descartes_core)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   moveit_core
   roscpp
-  cmake_modules
 )
 
 find_package(Boost REQUIRED)
@@ -21,10 +21,10 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    descartes_core
+    ${PROJECT_NAME}
   CATKIN_DEPENDS
-    roscpp
     moveit_core
+    roscpp
   DEPENDS
     Boost
     EIGEN3
@@ -39,11 +39,11 @@ include_directories(include
                     ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_library(descartes_core
+add_library(${PROJECT_NAME}
             src/trajectory_id.cpp
 )
 
-target_link_libraries(descartes_core
+target_link_libraries(${PROJECT_NAME}
                       ${catkin_LIBRARIES}
                       ${EIGEN3_LIBRARIES}
 )
@@ -53,7 +53,7 @@ target_link_libraries(descartes_core
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -4,16 +4,16 @@ project(descartes_moveit)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  moveit_core
-  tf
   cmake_modules
   descartes_core
   descartes_trajectory
+  moveit_core
   moveit_ros_planning
   pluginlib
+  rosconsole_bridge
+  tf
 )
 
-find_package(rosconsole_bridge REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
 
@@ -26,15 +26,15 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    descartes_moveit
+    ${PROJECT_NAME}
   CATKIN_DEPENDS
-    moveit_core
-    tf
     cmake_modules
     descartes_core
     descartes_trajectory
-  DEPENDS
+    moveit_core
     rosconsole_bridge
+    tf
+  DEPENDS
     Boost
     EIGEN3
 )
@@ -49,13 +49,13 @@ include_directories(include
 )
 
 ## Descartes MoveIt lib
-add_library(descartes_moveit
+add_library(${PROJECT_NAME}
+            src/ikfast_moveit_state_adapter.cpp
             src/moveit_state_adapter.cpp
             src/plugin_init.cpp
             src/seed_search.cpp
-            src/ikfast_moveit_state_adapter.cpp
 )
-target_link_libraries(descartes_moveit
+target_link_libraries(${PROJECT_NAME}
                       ${catkin_LIBRARIES}
 )
 
@@ -64,8 +64,12 @@ target_link_libraries(descartes_moveit
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(
+  FILES moveit_adapter_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(
     DIRECTORY include/${PROJECT_NAME}/

--- a/descartes_planner/CMakeLists.txt
+++ b/descartes_planner/CMakeLists.txt
@@ -4,12 +4,12 @@ project(descartes_planner)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   descartes_core
   descartes_trajectory
   moveit_core
-  roscpp
   pluginlib
-  cmake_modules
+  roscpp
 )
 
 find_package(Boost REQUIRED)
@@ -34,12 +34,12 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    descartes_planner
+    ${PROJECT_NAME}
   CATKIN_DEPENDS
-    roscpp
-    moveit_core
     descartes_core
     descartes_trajectory
+    moveit_core
+    roscpp
   DEPENDS
     Boost
     EIGEN3
@@ -55,29 +55,33 @@ include_directories(include
 )
 
 ## DescartesTrajectoryPt lib
-add_library(descartes_planner
-            src/planning_graph.cpp
-            src/sparse_planner.cpp
+add_library(${PROJECT_NAME}
             src/dense_planner.cpp
-            src/plugin_init.cpp
             src/ladder_graph_dag_search.cpp
+            src/planning_graph.cpp
+            src/plugin_init.cpp
+            src/sparse_planner.cpp
 )
 
-target_link_libraries(descartes_planner
+target_link_libraries(${PROJECT_NAME}
                       ${catkin_LIBRARIES}
                       ${OpenMP_FLAGS}
 )
 
-target_compile_options(descartes_planner PRIVATE ${OpenMP_FLAGS})
+target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_FLAGS})
 
-add_dependencies(descartes_planner ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 #############
 ## Install ##
 #############
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(
+  FILES ${PROJECT_NAME}_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(
     DIRECTORY include/${PROJECT_NAME}/

--- a/descartes_tests/CMakeLists.txt
+++ b/descartes_tests/CMakeLists.txt
@@ -70,7 +70,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(${PROJECT_NAME}_planner_utest ${PROJECT_NAME})
 
   # Moveit adapter unit tests
-  find_package(rostest)
+  find_package(rostest REQUIRED)
   add_rostest_gtest(${PROJECT_NAME}_moveit_utest
     test/moveit/launch/utest.launch
     test/moveit/utest.cpp

--- a/descartes_tests/package.xml
+++ b/descartes_tests/package.xml
@@ -11,6 +11,7 @@
   <license>Apache 2.0</license>
 
   <test_depend>gtest</test_depend>
+  <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>moveit_kinematics</test_depend>
 

--- a/descartes_trajectory/CMakeLists.txt
+++ b/descartes_trajectory/CMakeLists.txt
@@ -25,11 +25,11 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    descartes_trajectory
+    ${PROJECT_NAME}
   CATKIN_DEPENDS
-    roscpp
-    moveit_core
     descartes_core
+    moveit_core
+    roscpp
   DEPENDS
     Boost
     EIGEN3
@@ -45,14 +45,14 @@ include_directories(include
                     ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_library(descartes_trajectory
+add_library(${PROJECT_NAME}
+            src/axial_symmetric_pt.cpp
             src/cart_trajectory_pt.cpp
             src/joint_trajectory_pt.cpp
             src/trajectory.cpp
-            src/axial_symmetric_pt.cpp
 )
 
-target_link_libraries(descartes_trajectory
+target_link_libraries(${PROJECT_NAME}
                       ${catkin_LIBRARIES}
 )
 
@@ -62,7 +62,7 @@ target_link_libraries(descartes_trajectory
 #############
 
 install(
-    TARGETS ${PROJECT_NAME} 
+    TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(
@@ -81,5 +81,5 @@ if(CATKIN_ENABLE_TESTING)
   )
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
   target_compile_definitions(${PROJECT_NAME}_utest PUBLIC GTEST_USE_OWN_TR1_TUPLE=0)
-  target_link_libraries(${PROJECT_NAME}_utest descartes_trajectory)
+  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
 endif()

--- a/descartes_trajectory/package.xml
+++ b/descartes_trajectory/package.xml
@@ -3,7 +3,7 @@
   <name>descartes_trajectory</name>
   <version>0.0.1</version>
   <description>The descartes_trajectory package</description>
-  
+
   <maintainer email="jnicho@swri.org">Jorge Nicho</maintainer>
   <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
@@ -21,6 +21,8 @@
   <run_depend>descartes_core</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
+
+  <test_depend>rosunit</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/descartes_utilities/CMakeLists.txt
+++ b/descartes_utilities/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES descartes_utilities
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS descartes_core descartes_trajectory trajectory_msgs
 )
 
@@ -24,7 +24,7 @@ add_library(${PROJECT_NAME}
   src/ros_conversions.cpp
 )
 
-add_dependencies(${PROJECT_NAME} 
+add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
 )
 


### PR DESCRIPTION
Fixes #221 

Main fixes
- Sorting strings alphabetically
- Replacing project name strings by `${PROJECT_NAME}`
- Making sure all files are installed

There are still some warnings because of the descriptions of the packages, this really is minor:
```bash
./descartes_moveit
catkin_lint: checked 1 packages and found 0 problems
./descartes_planner
descartes_planner: notice: meaningless package description 'The descartes_planner package'
catkin_lint: checked 1 packages and found 1 problems
./descartes_tests
descartes_tests: notice: package description starts with boilerplate 'A package'
catkin_lint: checked 1 packages and found 1 problems
./.git
catkin_lint: no packages to check
./descartes_core
descartes_core: notice: package description starts with boilerplate 'The descartes_core package'
catkin_lint: checked 1 packages and found 1 problems
./descartes_trajectory
descartes_trajectory: notice: meaningless package description 'The descartes_trajectory package'
catkin_lint: checked 1 packages and found 1 problems
./descartes_utilities
descartes_utilities: notice: package description starts with boilerplate 'This package contains'
catkin_lint: checked 1 packages and found 1 problems
./descartes
descartes: notice: package description starts with boilerplate 'Descartes is a'
catkin_lint: checked 1 packages and found 1 problems

```