### PR TITLE
Remove moveit_core dependency in descartes_planner as it is not used

### DIFF
--- a/descartes_planner/CMakeLists.txt
+++ b/descartes_planner/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   descartes_core
   descartes_trajectory
-  moveit_core
   pluginlib
   roscpp
 )
@@ -38,7 +37,6 @@ catkin_package(
   CATKIN_DEPENDS
     descartes_core
     descartes_trajectory
-    moveit_core
     roscpp
   DEPENDS
     Boost

--- a/descartes_planner/package.xml
+++ b/descartes_planner/package.xml
@@ -17,7 +17,6 @@
   <build_depend>descartes_core</build_depend>
   <build_depend>descartes_trajectory</build_depend>
   <build_depend>boost</build_depend>
-  <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
@@ -26,7 +25,6 @@
   <run_depend>descartes_core</run_depend>
   <run_depend>descartes_trajectory</run_depend>
   <run_depend>boost</run_depend>
-  <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
 


### PR DESCRIPTION
```bash
descartes/descartes_planner$ grep -irn "moveit"
package.xml:20:  <build_depend>moveit_core</build_depend>
package.xml:29:  <run_depend>moveit_core</run_depend>
CMakeLists.txt:9:  moveit_core
CMakeLists.txt:40:    moveit_core
```

`moveit_core` is not a dependency, you can remove it