### PR TITLE
Adding collision checking capabilities to Descartes and preparing for changes to the IKFast templates

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -23,6 +23,13 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include "descartes_core/utils.h"
 
+
+namespace planning_scene_monitor
+{
+  MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);
+  class PlanningSceneMonitor;
+}
+
 namespace descartes_core
 {
 DESCARTES_CLASS_FORWARD(RobotModel);
@@ -107,7 +114,8 @@ public:
    * a fixed location relative to the last link in 'group_name'.
    */
   virtual bool initialize(const std::string &robot_description, const std::string &group_name,
-                          const std::string &world_frame, const std::string &tcp_frame) = 0;
+                          const std::string &world_frame, const std::string &tcp_frame,
+                          planning_scene_monitor::PlanningSceneMonitorPtr psm = nullptr) = 0;
 
   /**
    * @brief Enables collision checks

--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -31,7 +31,8 @@ public:
   }
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& world_frame, const std::string& tcp_frame);
+                          const std::string& world_frame, const std::string& tcp_frame,
+                          planning_scene_monitor::PlanningSceneMonitorPtr psm = nullptr);
 
   virtual bool getAllIK(const Eigen::Affine3d& pose, std::vector<std::vector<double> >& joint_poses) const;
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -21,10 +21,17 @@
 
 #include "descartes_core/robot_model.h"
 #include "descartes_trajectory/cart_trajectory_pt.h"
-#include <moveit/planning_scene/planning_scene.h>
+
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <string>
+
+
+namespace planning_scene_monitor
+{
+  MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);
+  class PlanningSceneMonitor;
+}
 
 namespace descartes_moveit
 {
@@ -41,10 +48,12 @@ public:
   }
 
   virtual bool initialize(const std::string &robot_description, const std::string &group_name,
-                          const std::string &world_frame, const std::string &tcp_frame);
+                          const std::string &world_frame, const std::string &tcp_frame,
+                          planning_scene_monitor::PlanningSceneMonitorPtr psm = nullptr);
 
   virtual bool initialize(robot_model::RobotModelConstPtr robot_model, const std::string &group_name,
-                          const std::string &world_frame, const std::string &tcp_frame);
+                          const std::string &world_frame, const std::string &tcp_frame,
+                          planning_scene_monitor::PlanningSceneMonitorPtr psm = nullptr);
 
   virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const;
@@ -128,8 +137,6 @@ protected:
 
   mutable moveit::core::RobotStatePtr robot_state_;
 
-  planning_scene::PlanningScenePtr planning_scene_;
-
   robot_model::RobotModelConstPtr robot_model_ptr_;
 
   robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
@@ -147,6 +154,11 @@ protected:
   std::string group_name_;
 
   /**
+   * @brief name of parameter for robot URDF
+   */
+  std::string robot_description_ = "robot_description";
+
+  /**
    * @brief Tool frame name
    */
   std::string tool_frame_;
@@ -160,6 +172,11 @@ protected:
    * @brief convenient transformation frame
    */
   descartes_core::Frame world_to_root_;
+
+  /**
+   * @brief Planning scene monitor (used to update internal planning scene)
+   */
+  mutable planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };
 
 }  // descartes_moveit

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="jnicho@swri.org">Jorge Nicho</maintainer>
   <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
-  
+
   <license>Apache2</license>
 
   <author >Shaun Edwards</author>

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "descartes_moveit/ikfast_moveit_state_adapter.h"
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 #include <eigen_conversions/eigen_msg.h>
 #include <ros/node_handle.h>
@@ -54,9 +55,10 @@ static size_t closestJointPose(const std::vector<double>& target, const std::vec
 bool descartes_moveit::IkFastMoveitStateAdapter::initialize(const std::string& robot_description,
                                                             const std::string& group_name,
                                                             const std::string& world_frame,
-                                                            const std::string& tcp_frame)
+                                                            const std::string& tcp_frame,
+                                                            planning_scene_monitor::PlanningSceneMonitorPtr psm)
 {
-  if (!MoveitStateAdapter::initialize(robot_description, group_name, world_frame, tcp_frame))
+  if (!MoveitStateAdapter::initialize(robot_description, group_name, world_frame, tcp_frame, psm))
   {
     return false;
   }
@@ -70,12 +72,9 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d&
   joint_poses.clear();
   const auto& solver = joint_group_->getSolverInstance();
 
-  // Transform input pose
-  Eigen::Affine3d tool_pose = world_to_base_.frame_inv * pose * tool0_to_tip_.frame;
-
   // convert to geometry_msgs ...
   geometry_msgs::Pose geometry_pose;
-  tf::poseEigenToMsg(tool_pose, geometry_pose);
+  tf::poseEigenToMsg(pose, geometry_pose);
   std::vector<geometry_msgs::Pose> poses = { geometry_pose };
 
   std::vector<double> dummy_seed(getDOF(), 0.0);

--- a/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
@@ -102,10 +102,10 @@ struct ToleranceBase
     , y_lower(y_lower_lim)
     , z_lower(z_lower_lim)
   {
-    ROS_DEBUG_STREAM("Creating fully defined Tolerance(base type)");
-    ROS_DEBUG_STREAM("Initializing x tolerance (lower/upper)" << x_lower << "/" << x_upper);
-    ROS_DEBUG_STREAM("Initializing y tolerance (lower/upper)" << y_lower << "/" << y_upper);
-    ROS_DEBUG_STREAM("Initializing z tolerance (lower/upper)" << z_lower << "/" << z_upper);
+    ROS_DEBUG_STREAM_NAMED("ToleranceBase", "Creating fully defined Tolerance(base type)");
+    ROS_DEBUG_STREAM_NAMED("ToleranceBase", "Initializing x tolerance (lower/upper)" << x_lower << "/" << x_upper);
+    ROS_DEBUG_STREAM_NAMED("ToleranceBase", "Initializing y tolerance (lower/upper)" << y_lower << "/" << y_upper);
+    ROS_DEBUG_STREAM_NAMED("ToleranceBase", "Initializing z tolerance (lower/upper)" << z_lower << "/" << z_upper);
   }
 
   void clear()
@@ -129,7 +129,7 @@ struct PositionTolerance : public ToleranceBase
                     double z_upper_lim)
     : ToleranceBase(x_lower_lim, x_upper_lim, y_lower_lim, y_upper_lim, z_lower_lim, z_upper_lim)
   {
-    ROS_DEBUG_STREAM("Created fully defined Position Tolerance");
+    ROS_DEBUG_STREAM_NAMED("PositionTolerance", "Created fully defined Position Tolerance");
   }
 };
 
@@ -146,7 +146,7 @@ struct OrientationTolerance : public ToleranceBase
                        double z_lower_lim, double z_upper_lim)
     : ToleranceBase(x_lower_lim, x_upper_lim, y_lower_lim, y_upper_lim, z_lower_lim, z_upper_lim)
   {
-    ROS_DEBUG_STREAM("Created fully defined Orientation Tolerance");
+    ROS_DEBUG_STREAM_NAMED("OrientationTolerance","Created fully defined Orientation Tolerance");
   }
 };
 

--- a/descartes_trajectory/src/cart_trajectory_pt.cpp
+++ b/descartes_trajectory/src/cart_trajectory_pt.cpp
@@ -83,7 +83,7 @@ EigenSTL::vector_Affine3d uniform(const TolerancedFrame &frame, const double ori
   // Estimating the number of samples base on tolerance zones and sampling increment.
   size_t est_num_samples = ntx * nty * ntz * nrx * nry * nrz;
 
-  ROS_DEBUG_STREAM("Estimated number of samples: " << est_num_samples << ", reserving space");
+  ROS_DEBUG_STREAM_NAMED("Descartes", "Estimated number of samples: " << est_num_samples << ", reserving space");
   rtn.reserve(est_num_samples);
 
   // TODO: The following for loops do not ensure that the rull range is sample (lower to upper)
@@ -124,9 +124,10 @@ EigenSTL::vector_Affine3d uniform(const TolerancedFrame &frame, const double ori
       }
     }
   }
-  ROS_DEBUG_STREAM("Uniform sampling of frame, utilizing orientation increment: "
-                   << orient_increment << ", and position increment: " << pos_increment << " resulted in " << rtn.size()
-                   << " samples");
+  ROS_DEBUG_STREAM_NAMED("Descartes",
+                         "Uniform sampling of frame, utilizing orientation increment: " << orient_increment <<
+                         ", and position increment: " << pos_increment <<
+                         " resulted in " << rtn.size() << " samples");
   return rtn;
 }
 
@@ -260,8 +261,8 @@ void CartTrajectoryPt::getCartesianPoses(const RobotModel &model, EigenSTL::vect
   }
   else
   {
-    ROS_DEBUG_STREAM("Get cartesian poses, sampled: " << all_poses.size() << ", with " << poses.size()
-                                                      << " valid(returned) poses");
+    ROS_DEBUG_STREAM_NAMED("Descartes", "Get cartesian poses, sampled: " << all_poses.size() << ", with " << poses.size()
+                                                                         << " valid(returned) poses");
   }
 }
 
@@ -397,8 +398,8 @@ void CartTrajectoryPt::getJointPoses(const RobotModel &model, std::vector<std::v
   }
   else
   {
-    ROS_DEBUG_STREAM("Get joint poses, sampled: " << poses.size() << ", with " << joint_poses.size()
-                                                  << " valid(returned) poses");
+    ROS_DEBUG_STREAM_NAMED("Descartes", "Get joint poses, sampled: " << poses.size() << ", with " << joint_poses.size()
+                                                                     << " valid(returned) poses");
   }
 }
 


### PR DESCRIPTION
Adds collision checking capabilities to Descartes using the MoveIt! planning scene monitor. 
This is fundamentally different from the kinetic-godel version which is unable to take in a planning scene monitor which uses the planning scene spun up by the `demo.launch` script in moveit_config packages.
  
These changes are used by the Descartes MoveIt! capability that will soon be open sourced. It is unclear if these changes should live in a separate branch, fork, or if they should be merged into master. This PR is meant as a conversation starter. 

This PR is a result of a collaboration between [Carbon Robotics](http://www.carbon.ai/) and [PickNik Robotics](picknik.ai)