### PR TITLE
Melodic migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ notifications:
 env:
   matrix:
     - USE_DEB=true  
-      ROS_DISTRO="kinetic" 
+      ROS_DISTRO="melodic" 
       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true  
-      ROS_DISTRO="kinetic" 
+      ROS_DISTRO="melodic" 
       ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -19,7 +19,7 @@
 #ifndef ROBOT_KINEMATICS_H_
 #define ROBOT_KINEMATICS_H_
 
-// TODO: The include below picks up Eigen::Affine3d, but there is probably a better way
+// TODO: The include below picks up Eigen::Isometry3d, but there is probably a better way
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include "descartes_core/utils.h"
 
@@ -50,7 +50,7 @@ public:
    * @param joint_pose Solution (if function successful).
    * @return True if successful
    */
-  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+  virtual bool getIK(const Eigen::Isometry3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const = 0;
 
   /**
@@ -61,7 +61,7 @@ public:
    * @param joint_poses Solution (if function successful).
    * @return True if successful
    */
-  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const = 0;
+  virtual bool getAllIK(const Eigen::Isometry3d &pose, std::vector<std::vector<double> > &joint_poses) const = 0;
 
   /**
    * @brief Returns the affine pose
@@ -69,7 +69,7 @@ public:
    * @param pose Affine pose of TOOL in WOBJ frame
    * @return True if successful
    */
-  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const = 0;
+  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Isometry3d &pose) const = 0;
 
   /**
    * @brief Returns number of DOFs
@@ -89,7 +89,7 @@ public:
    * @param pose Affine pose of TOOL in WOBJ frame
    * @return True if valid
    */
-  virtual bool isValid(const Eigen::Affine3d &pose) const = 0;
+  virtual bool isValid(const Eigen::Isometry3d &pose) const = 0;
 
   /**
    * @brief Returns the joint velocity limits for each joint in the robot kinematic model

--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -42,15 +42,15 @@ namespace descartes_core
 struct Frame
 {
   Frame(){};
-  Frame(const Eigen::Affine3d &a) : frame(a), frame_inv(a.inverse()){};
+  Frame(const Eigen::Isometry3d &a) : frame(a), frame_inv(a.inverse()){};
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
-  Eigen::Affine3d frame;
-  Eigen::Affine3d frame_inv;
+  Eigen::Isometry3d frame;
+  Eigen::Isometry3d frame_inv;
 
   static const Frame Identity()
   {
-    return Frame(Eigen::Affine3d::Identity());
+    return Frame(Eigen::Isometry3d::Identity());
   }
 };
 
@@ -90,7 +90,7 @@ public:
    * @return True if calculation successful. pose untouched if return false.
    */
   virtual bool getClosestCartPose(const std::vector<double> &seed_state, const RobotModel &kinematics,
-                                  Eigen::Affine3d &pose) const = 0;
+                                  Eigen::Isometry3d &pose) const = 0;
 
   /**@brief Get single Cartesian pose associated with nominal of this point.
     * (Pose of TOOL point expressed in WOBJ frame).
@@ -100,13 +100,13 @@ public:
     * @return True if calculation successful. pose untouched if return false.
     */
   virtual bool getNominalCartPose(const std::vector<double> &seed_state, const RobotModel &kinematics,
-                                  Eigen::Affine3d &pose) const = 0;
+                                  Eigen::Isometry3d &pose) const = 0;
 
   /**@brief Get "all" Cartesian poses that satisfy this point.
    * @param kinematics Kinematics object used to calculate pose
    * @param poses Note: Number of poses returned may be subject to discretization used.
    */
-  virtual void getCartesianPoses(const RobotModel &kinematics, EigenSTL::vector_Affine3d &poses) const = 0;
+  virtual void getCartesianPoses(const RobotModel &kinematics, EigenSTL::vector_Isometry3d &poses) const = 0;
   /** @} (end section) */
 
   /**@name Getters for joint pose(s)

--- a/descartes_core/include/descartes_core/trajectory_pt.h
+++ b/descartes_core/include/descartes_core/trajectory_pt.h
@@ -43,6 +43,13 @@ struct Frame
 {
   Frame(){};
   Frame(const Eigen::Isometry3d &a) : frame(a), frame_inv(a.inverse()){};
+  Frame(const Eigen::Affine3d& a)
+  {
+    Eigen::Isometry3d t;
+    frame.translation() = a.translation();
+    frame.linear() = a.rotation();
+    frame_inv = frame.inverse();
+  }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
   Eigen::Isometry3d frame;

--- a/descartes_core/include/descartes_core/utils.h
+++ b/descartes_core/include/descartes_core/utils.h
@@ -56,12 +56,12 @@ enum EulerConvention
 typedef EulerConventions::EulerConvention EulerConvention;
 
 // Use a function declaration so that we can add the 'unused' attribute, which prevents compiler warnings
-static Eigen::Affine3d toFrame(double tx, double ty, double tz, double rx, double ry, double rz,
+static Eigen::Isometry3d toFrame(double tx, double ty, double tz, double rx, double ry, double rz,
                                int convention = int(EulerConventions::ZYX)) __attribute__((unused));
 
-static Eigen::Affine3d toFrame(double tx, double ty, double tz, double rx, double ry, double rz, int convention)
+static Eigen::Isometry3d toFrame(double tx, double ty, double tz, double rx, double ry, double rz, int convention)
 {
-  Eigen::Affine3d rtn;
+  Eigen::Isometry3d rtn;
 
   switch (convention)
   {

--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -33,12 +33,12 @@ public:
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& world_frame, const std::string& tcp_frame);
 
-  virtual bool getAllIK(const Eigen::Affine3d& pose, std::vector<std::vector<double> >& joint_poses) const;
+  virtual bool getAllIK(const Eigen::Isometry3d& pose, std::vector<std::vector<double> >& joint_poses) const;
 
-  virtual bool getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state,
+  virtual bool getIK(const Eigen::Isometry3d& pose, const std::vector<double>& seed_state,
                      std::vector<double>& joint_pose) const;
 
-  virtual bool getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const;
+  virtual bool getFK(const std::vector<double>& joint_pose, Eigen::Isometry3d& pose) const;
 
   /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -46,16 +46,16 @@ public:
   virtual bool initialize(robot_model::RobotModelConstPtr robot_model, const std::string &group_name,
                           const std::string &world_frame, const std::string &tcp_frame);
 
-  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+  virtual bool getIK(const Eigen::Isometry3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const;
 
-  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
+  virtual bool getAllIK(const Eigen::Isometry3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
-  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const;
+  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Isometry3d &pose) const;
 
   virtual bool isValid(const std::vector<double> &joint_pose) const;
 
-  virtual bool isValid(const Eigen::Affine3d &pose) const;
+  virtual bool isValid(const Eigen::Isometry3d &pose) const;
 
   virtual int getDOF() const;
 
@@ -103,7 +103,7 @@ protected:
    * @param joint_pose Solution (if function successful).
    * @return
    */
-  bool getIK(const Eigen::Affine3d &pose, std::vector<double> &joint_pose) const;
+  bool getIK(const Eigen::Isometry3d &pose, std::vector<double> &joint_pose) const;
 
   /**
    * TODO: Checks for collisions at this joint pose. The setCollisionCheck(true) must have been

--- a/descartes_moveit/include/descartes_moveit/utils.h
+++ b/descartes_moveit/include/descartes_moveit/utils.h
@@ -1,0 +1,63 @@
+/*
+ * utils.h
+ *
+ *  Created on: Feb 1, 2019
+ *      Author: Jorge Nicho
+ */
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019, Jorge Nicho
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_DESCARTES_MOVEIT_UTILS_H_
+#define INCLUDE_DESCARTES_MOVEIT_UTILS_H_
+
+#include <Eigen/Core>
+
+namespace descartes_moveit
+{
+
+/**
+ * @brief utility function that converts an Eigen Affine Transform type to an Isometry one.
+ * @param t The Affine transform
+ * @return  An Isometry transform
+ */
+template <class T>
+static Eigen::Transform<T,3,Eigen::Isometry> toIsometry(const Eigen::Transform<T,3,Eigen::Affine>& t)
+{
+  Eigen::Transform<T,3,Eigen::Isometry> o;
+  o.translation() = t.translation();
+  o.linear() = t.rotation();
+  return std::move(o);
+}
+
+/**
+ * @brief workaround to allow compatibility with previous versions of MoveIt! that used Affine3 as the
+ *  preferred transform type.
+ * @param t The Affine transform
+ * @return  An Isometry transform
+ */
+template <class T>
+static Eigen::Transform<T,3,Eigen::Isometry> toIsometry(const Eigen::Transform<T,3,Eigen::Isometry>& t)
+{
+  return std::move(Eigen::Transform<T,3,Eigen::Isometry>(t));
+}
+
+}
+
+
+
+#endif /* INCLUDE_DESCARTES_MOVEIT_UTILS_H_ */

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -64,14 +64,14 @@ bool descartes_moveit::IkFastMoveitStateAdapter::initialize(const std::string& r
   return computeIKFastTransforms();
 }
 
-bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d& pose,
+bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Isometry3d& pose,
                                                           std::vector<std::vector<double>>& joint_poses) const
 {
   joint_poses.clear();
   const auto& solver = joint_group_->getSolverInstance();
 
   // Transform input pose
-  Eigen::Affine3d tool_pose = world_to_base_.frame_inv * pose * tool0_to_tip_.frame;
+  Eigen::Isometry3d tool_pose = world_to_base_.frame_inv * pose * tool0_to_tip_.frame;
 
   // convert to geometry_msgs ...
   geometry_msgs::Pose geometry_pose;
@@ -97,7 +97,7 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getAllIK(const Eigen::Affine3d&
   return joint_poses.size() > 0;
 }
 
-bool descartes_moveit::IkFastMoveitStateAdapter::getIK(const Eigen::Affine3d& pose,
+bool descartes_moveit::IkFastMoveitStateAdapter::getIK(const Eigen::Isometry3d& pose,
                                                        const std::vector<double>& seed_state,
                                                        std::vector<double>& joint_pose) const
 {
@@ -111,7 +111,7 @@ bool descartes_moveit::IkFastMoveitStateAdapter::getIK(const Eigen::Affine3d& po
 }
 
 bool descartes_moveit::IkFastMoveitStateAdapter::getFK(const std::vector<double>& joint_pose,
-                                                       Eigen::Affine3d& pose) const
+                                                       Eigen::Isometry3d& pose) const
 {
   const auto& solver = joint_group_->getSolverInstance();
 

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -63,7 +63,7 @@ bool getJointVelocityLimits(const moveit::core::RobotState& state, const std::st
 
 namespace descartes_moveit
 {
-MoveitStateAdapter::MoveitStateAdapter() : world_to_root_(Eigen::Affine3d::Identity())
+MoveitStateAdapter::MoveitStateAdapter() : world_to_root_(Eigen::Isometry3d::Identity())
 {
 }
 
@@ -133,26 +133,26 @@ bool MoveitStateAdapter::initialize(robot_model::RobotModelConstPtr robot_model,
               " transformed to world frame '%s'",
               __FUNCTION__, world_frame_.c_str(), model_frame.c_str(), world_frame_.c_str());
 
-    Eigen::Affine3d root_to_world = robot_state_->getFrameTransform(world_frame_);
+    Eigen::Isometry3d root_to_world = robot_state_->getFrameTransform(world_frame_);
     world_to_root_ = descartes_core::Frame(root_to_world.inverse());
   }
 
   return true;
 }
 
-bool MoveitStateAdapter::getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state,
+bool MoveitStateAdapter::getIK(const Eigen::Isometry3d& pose, const std::vector<double>& seed_state,
                                std::vector<double>& joint_pose) const
 {
   robot_state_->setJointGroupPositions(group_name_, seed_state);
   return getIK(pose, joint_pose);
 }
 
-bool MoveitStateAdapter::getIK(const Eigen::Affine3d& pose, std::vector<double>& joint_pose) const
+bool MoveitStateAdapter::getIK(const Eigen::Isometry3d& pose, std::vector<double>& joint_pose) const
 {
   bool rtn = false;
 
   // transform to group base
-  Eigen::Affine3d tool_pose = world_to_root_.frame * pose;
+  Eigen::Isometry3d tool_pose = world_to_root_.frame * pose;
 
   if (robot_state_->setFromIK(joint_group_, tool_pose, tool_frame_))
   {
@@ -174,7 +174,7 @@ bool MoveitStateAdapter::getIK(const Eigen::Affine3d& pose, std::vector<double>&
   return rtn;
 }
 
-bool MoveitStateAdapter::getAllIK(const Eigen::Affine3d& pose, std::vector<std::vector<double> >& joint_poses) const
+bool MoveitStateAdapter::getAllIK(const Eigen::Isometry3d& pose, std::vector<std::vector<double> >& joint_poses) const
 {
   // The minimum difference between solutions should be greater than the search discretization
   // used by the IK solver.  This value is multiplied by 4 to remove any chance that a solution
@@ -258,7 +258,7 @@ bool MoveitStateAdapter::isInLimits(const std::vector<double> &joint_pose) const
   return joint_group_->satisfiesPositionBounds(joint_pose.data());
 }
 
-bool MoveitStateAdapter::getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const
+bool MoveitStateAdapter::getFK(const std::vector<double>& joint_pose, Eigen::Isometry3d& pose) const
 {
   bool rtn = false;
   robot_state_->setJointGroupPositions(group_name_, joint_pose);
@@ -298,7 +298,7 @@ bool MoveitStateAdapter::isValid(const std::vector<double>& joint_pose) const
   return isInLimits(joint_pose) && !isInCollision(joint_pose);
 }
 
-bool MoveitStateAdapter::isValid(const Eigen::Affine3d& pose) const
+bool MoveitStateAdapter::isValid(const Eigen::Isometry3d& pose) const
 {
   // TODO: Could check robot extents first as a quick check
   std::vector<double> dummy;

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -18,9 +18,11 @@
 
 #include <console_bridge/console.h>
 
+#include "descartes_moveit/utils.h"
 #include "descartes_moveit/moveit_state_adapter.h"
 #include "descartes_core/pretty_print.hpp"
 #include "descartes_moveit/seed_search.h"
+
 
 #include <eigen_conversions/eigen_msg.h>
 #include <random_numbers/random_numbers.h>
@@ -133,7 +135,7 @@ bool MoveitStateAdapter::initialize(robot_model::RobotModelConstPtr robot_model,
               " transformed to world frame '%s'",
               __FUNCTION__, world_frame_.c_str(), model_frame.c_str(), world_frame_.c_str());
 
-    Eigen::Isometry3d root_to_world = robot_state_->getFrameTransform(world_frame_);
+    Eigen::Isometry3d root_to_world = toIsometry(robot_state_->getFrameTransform(world_frame_));
     world_to_root_ = descartes_core::Frame(root_to_world.inverse());
   }
 
@@ -266,7 +268,8 @@ bool MoveitStateAdapter::getFK(const std::vector<double>& joint_pose, Eigen::Iso
   {
     if (robot_state_->knowsFrameTransform(tool_frame_))
     {
-      pose = world_to_root_.frame * robot_state_->getFrameTransform(tool_frame_);
+      pose = toIsometry(world_to_root_.frame * robot_state_->getFrameTransform(tool_frame_));
+      //pose.
       rtn = true;
     }
     else

--- a/descartes_moveit/src/seed_search.cpp
+++ b/descartes_moveit/src/seed_search.cpp
@@ -14,7 +14,7 @@ typedef std::vector<JointConfig> JointConfigVec;
  * @brief Forward kinematics helper
  */
 bool doFK(moveit::core::RobotState& state, const moveit::core::JointModelGroup* group, const std::string& tool,
-          const JointConfig& joint_pose, Eigen::Affine3d& result)
+          const JointConfig& joint_pose, Eigen::Isometry3d& result)
 {
   state.setJointGroupPositions(group, joint_pose);
   if (!state.knowsFrameTransform(tool))
@@ -38,7 +38,7 @@ bool doFK(moveit::core::RobotState& state, const moveit::core::JointModelGroup* 
  *        May return false if IK failed.
  */
 bool doIK(moveit::core::RobotState& state, const moveit::core::JointModelGroup* group, const std::string& group_name,
-          const std::string& tool, const Eigen::Affine3d& pose, const JointConfig& seed, JointConfig& result)
+          const std::string& tool, const Eigen::Isometry3d& pose, const JointConfig& seed, JointConfig& result)
 {
   const static int N_ATTEMPTS = 1;
   const static double IK_TIMEOUT = 0.01;
@@ -151,7 +151,7 @@ JointConfigVec findSeedStatesForPair(moveit::core::RobotState& state, const std:
     JointConfigVec this_round_iks;
 
     // Forward kinematics
-    Eigen::Affine3d target_pose;
+    Eigen::Isometry3d target_pose;
     if (!doFK(state, group, tool_frame, round_ik, target_pose))
     {
       ROS_DEBUG_STREAM("No FK for pose " << i);

--- a/descartes_moveit/src/seed_search.cpp
+++ b/descartes_moveit/src/seed_search.cpp
@@ -1,3 +1,4 @@
+#include "descartes_moveit/utils.h"
 #include <descartes_moveit/seed_search.h>
 
 #include <ros/ros.h>
@@ -29,7 +30,7 @@ bool doFK(moveit::core::RobotState& state, const moveit::core::JointModelGroup* 
     return false;
   }
 
-  result = state.getFrameTransform(tool);
+  result = toIsometry(state.getFrameTransform(tool));
   return true;
 }
 

--- a/descartes_tests/CMakeLists.txt
+++ b/descartes_tests/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   descartes_moveit
   descartes_planner
   descartes_trajectory
+  eigen_conversions
 )
 
 catkin_package(
@@ -18,6 +19,7 @@ catkin_package(
     descartes_moveit
     descartes_planner
     descartes_trajectory
+    eigen_conversions
 )
 
 include_directories(

--- a/descartes_tests/include/descartes_tests/cartesian_robot.h
+++ b/descartes_tests/include/descartes_tests/cartesian_robot.h
@@ -35,16 +35,16 @@ public:
   CartesianRobot(double pos_range, double orient_range,
                  const std::vector<double> &joint_velocities = std::vector<double>(6, 1.0));
 
-  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+  virtual bool getIK(const Eigen::Isometry3d &pose, const std::vector<double> &seed_state,
                      std::vector<double> &joint_pose) const;
 
-  virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
+  virtual bool getAllIK(const Eigen::Isometry3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
-  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const;
+  virtual bool getFK(const std::vector<double> &joint_pose, Eigen::Isometry3d &pose) const;
 
   virtual bool isValid(const std::vector<double> &joint_pose) const;
 
-  virtual bool isValid(const Eigen::Affine3d &pose) const;
+  virtual bool isValid(const Eigen::Isometry3d &pose) const;
 
   virtual int getDOF() const;
 

--- a/descartes_tests/package.xml
+++ b/descartes_tests/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>descartes_tests</name>
   <version>0.1.0</version>
   <description>
@@ -16,11 +16,10 @@
   <test_depend>moveit_kinematics</test_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>descartes_moveit</build_depend>
-  <build_depend>descartes_planner</build_depend>
-  <build_depend>descartes_trajectory</build_depend>
-  <run_depend>descartes_moveit</run_depend>
-  <run_depend>descartes_planner</run_depend>
-  <run_depend>descartes_trajectory</run_depend>
+  <depend>descartes_moveit</depend>
+  <depend>descartes_planner</depend>
+  <depend>descartes_trajectory</depend>
+  <depend>eigen_conversions</depend>
+ 
 
 </package>

--- a/descartes_tests/src/cartesian_robot.cpp
+++ b/descartes_tests/src/cartesian_robot.cpp
@@ -63,7 +63,7 @@ bool CartesianRobot::isValidMove(const double *s, const double *f, double dt) co
   return true;
 }
 
-bool CartesianRobot::getIK(const Eigen::Affine3d &pose, const std::vector<double> &,
+bool CartesianRobot::getIK(const Eigen::Isometry3d &pose, const std::vector<double> &,
                            std::vector<double> &joint_pose) const
 {
   bool rtn = false;
@@ -87,14 +87,14 @@ bool CartesianRobot::getIK(const Eigen::Affine3d &pose, const std::vector<double
   return rtn;
 }
 
-bool CartesianRobot::getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const
+bool CartesianRobot::getAllIK(const Eigen::Isometry3d &pose, std::vector<std::vector<double> > &joint_poses) const
 {
   std::vector<double> empty;
   joint_poses.resize(1);
   return getIK(pose, empty, joint_poses[0]);
 }
 
-bool CartesianRobot::getFK(const std::vector<double> &joint_pose, Eigen::Affine3d &pose) const
+bool CartesianRobot::getFK(const std::vector<double> &joint_pose, Eigen::Isometry3d &pose) const
 {
   bool rtn = false;
 
@@ -141,7 +141,7 @@ bool CartesianRobot::isValid(const std::vector<double> &joint_pose) const
   return rtn;
 }
 
-bool CartesianRobot::isValid(const Eigen::Affine3d &pose) const
+bool CartesianRobot::isValid(const Eigen::Isometry3d &pose) const
 {
   bool rtn = false;
   double R, P, Y;

--- a/descartes_tests/test/planner/utils/trajectory_maker.cpp
+++ b/descartes_tests/test/planner/utils/trajectory_maker.cpp
@@ -14,7 +14,7 @@ std::vector<descartes_core::TrajectoryPtPtr> descartes_tests::makeConstantVeloci
   std::vector<descartes_core::TrajectoryPtPtr> result;
   for (size_t i = 0; i <= n_steps; ++i)
   {
-    Eigen::Affine3d pose;
+    Eigen::Isometry3d pose;
     pose = Eigen::Translation3d(start + i * step);
     descartes_core::TrajectoryPtPtr pt(new descartes_trajectory::CartTrajectoryPt(pose, tm));
     result.push_back(pt);
@@ -40,7 +40,7 @@ std::vector<descartes_core::TrajectoryPtPtr> descartes_tests::makeZigZagTrajecto
   std::vector<descartes_core::TrajectoryPtPtr> result;
   for (size_t i = 0; i <= n_steps; ++i)
   {
-    Eigen::Affine3d pose;
+    Eigen::Isometry3d pose;
     pose = Eigen::Translation3d(start + i * step);
     if (i & 1)
     {

--- a/descartes_tests/test/trajectory/axial_symmetric_pt.cpp
+++ b/descartes_tests/test/trajectory/axial_symmetric_pt.cpp
@@ -35,13 +35,13 @@ TEST(AxialSymPt, discretization_count)
   const double SEARCH_DISC = M_PI / 2.0;
   CartesianRobot robot(10.0, 2 * M_PI);
 
-  Eigen::Affine3d pose(Eigen::Affine3d::Identity());
+  Eigen::Isometry3d pose(Eigen::Isometry3d::Identity());
 
   AxialSymmetricPt z_point(pose, SEARCH_DISC, AxialSymmetricPt::Z_AXIS);
   AxialSymmetricPt x_point(pose, SEARCH_DISC, AxialSymmetricPt::X_AXIS);
   AxialSymmetricPt y_point(pose, SEARCH_DISC, AxialSymmetricPt::Y_AXIS);
 
-  EigenSTL::vector_Affine3d solutions;
+  EigenSTL::vector_Isometry3d solutions;
   std::vector<std::vector<double> > joint_solutions;
 
   const unsigned EXPECTED_POSES = (2.0 * M_PI / SEARCH_DISC) + 1;
@@ -72,7 +72,7 @@ TEST(AxialSymPt, discretization_values)
   const double SEARCH_DISC = M_PI / 2.0;
   CartesianRobot robot(10.0, 2 * M_PI);
 
-  Eigen::Affine3d pose(Eigen::Affine3d::Identity());
+  Eigen::Isometry3d pose(Eigen::Isometry3d::Identity());
 
   AxialSymmetricPt z_point(pose, SEARCH_DISC, AxialSymmetricPt::Z_AXIS);
   AxialSymmetricPt x_point(pose, SEARCH_DISC, AxialSymmetricPt::X_AXIS);
@@ -80,7 +80,7 @@ TEST(AxialSymPt, discretization_values)
 
   const double ANGLE_TOL = 0.001;
   //
-  EigenSTL::vector_Affine3d solutions;
+  EigenSTL::vector_Isometry3d solutions;
   z_point.getCartesianPoses(robot, solutions);
   for (std::size_t i = 0; i < solutions.size(); ++i)
   {

--- a/descartes_tests/test/trajectory/cart_trajectory_pt.cpp
+++ b/descartes_tests/test/trajectory/cart_trajectory_pt.cpp
@@ -38,7 +38,7 @@ TEST(CartTrajPt, zeroTolerance)
                                                 ToleranceBase::zeroTolerance<OrientationTolerance>(0.0, 0.0, 0.0)),
                                 0, 0);
 
-  EigenSTL::vector_Affine3d solutions;
+  EigenSTL::vector_Isometry3d solutions;
   std::vector<std::vector<double> > joint_solutions;
 
   CartesianRobot robot;
@@ -64,7 +64,7 @@ TEST(CartTrajPt, closestJointPose)
   const double ry = 0.0f;
   const double rz = M_PI / 4;
   std::vector<double> joint_pose = { x, y, z, rx, ry, rz };
-  Eigen::Affine3d frame_pose = descartes_core::utils::toFrame(x, y, z, rx, ry, rz);
+  Eigen::Isometry3d frame_pose = descartes_core::utils::toFrame(x, y, z, rx, ry, rz);
 
   ROS_INFO_STREAM("Initializing tolerance cartesian point");
   CartTrajectoryPt cart_point(
@@ -119,7 +119,7 @@ TEST(CartTrajPt, getPoses)
                       ToleranceBase::createSymmetric<OrientationTolerance>(0.0, 0.0, 0.0, ORIENT_TOL + EPSILON)),
       POS_INC, ORIENT_INC);
 
-  EigenSTL::vector_Affine3d solutions;
+  EigenSTL::vector_Isometry3d solutions;
   std::vector<std::vector<double> > joint_solutions;
 
   ROS_INFO_STREAM("Testing fuzzy pos point");

--- a/descartes_tests/test/trajectory/robot_model_test.hpp
+++ b/descartes_tests/test/trajectory/robot_model_test.hpp
@@ -83,7 +83,7 @@ TYPED_TEST_P(RobotModelTest, getIK)
   ROS_INFO_STREAM("Testing getIK");
   std::vector<double> fk_joint(6, 0.0);
   std::vector<double> ik_joint;
-  Eigen::Affine3d ik_pose, fk_pose;
+  Eigen::Isometry3d ik_pose, fk_pose;
   EXPECT_TRUE(this->model_->getFK(fk_joint, ik_pose));
   EXPECT_TRUE(this->model_->getIK(ik_pose, fk_joint, ik_joint));
   // This doesn't always work, but it should.  The IKFast solution doesn't
@@ -98,7 +98,7 @@ TYPED_TEST_P(RobotModelTest, getAllIK)
   ROS_INFO_STREAM("Testing getAllIK");
   std::vector<double> fk_joint(6, 0.5);
   std::vector<std::vector<double> > joint_poses;
-  Eigen::Affine3d ik_pose, fk_pose;
+  Eigen::Isometry3d ik_pose, fk_pose;
 
   EXPECT_TRUE(this->model_->getFK(fk_joint, ik_pose));
   EXPECT_TRUE(this->model_->getAllIK(ik_pose, joint_poses));

--- a/descartes_trajectory/include/descartes_trajectory/axial_symmetric_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/axial_symmetric_pt.h
@@ -69,7 +69,7 @@ public:
    * @brief Similar to other constructor except that it takes an affine pose instead of
    *        individual translation and rotation arguments.
    */
-  AxialSymmetricPt(const Eigen::Affine3d& pose, double orient_increment, FreeAxis axis,
+  AxialSymmetricPt(const Eigen::Isometry3d& pose, double orient_increment, FreeAxis axis,
                    const descartes_core::TimingConstraint& timing = descartes_core::TimingConstraint());
 
   virtual descartes_core::TrajectoryPtPtr copy() const

--- a/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/cart_trajectory_pt.h
@@ -156,7 +156,7 @@ struct OrientationTolerance : public ToleranceBase
 struct TolerancedFrame : public descartes_core::Frame
 {
   TolerancedFrame(){};
-  TolerancedFrame(const Eigen::Affine3d &a) : descartes_core::Frame(a)
+  TolerancedFrame(const Eigen::Isometry3d &a) : descartes_core::Frame(a)
   {
     Eigen::Vector3d t = a.translation();
     Eigen::Matrix3d m = a.rotation();
@@ -173,7 +173,7 @@ struct TolerancedFrame : public descartes_core::Frame
     orientation_tolerance = ToleranceBase::createSymmetric<OrientationTolerance>(rxyz(0), rxyz(1), rxyz(2), 0);
   };
 
-  TolerancedFrame(const Eigen::Affine3d &a, const PositionTolerance &pos_tol, const OrientationTolerance &orient_tol)
+  TolerancedFrame(const Eigen::Isometry3d &a, const PositionTolerance &pos_tol, const OrientationTolerance &orient_tol)
     : Frame(a), position_tolerance(pos_tol), orientation_tolerance(orient_tol)
   {
   }
@@ -257,14 +257,14 @@ public:
 
   // TODO complete
   virtual bool getClosestCartPose(const std::vector<double> &seed_state, const descartes_core::RobotModel &model,
-                                  Eigen::Affine3d &pose) const;
+                                  Eigen::Isometry3d &pose) const;
 
   // TODO complete
   virtual bool getNominalCartPose(const std::vector<double> &seed_state, const descartes_core::RobotModel &model,
-                                  Eigen::Affine3d &pose) const;
+                                  Eigen::Isometry3d &pose) const;
 
   // TODO complete
-  virtual void getCartesianPoses(const descartes_core::RobotModel &model, EigenSTL::vector_Affine3d &poses) const;
+  virtual void getCartesianPoses(const descartes_core::RobotModel &model, EigenSTL::vector_Isometry3d &poses) const;
   /** @} (end section) */
 
   /**@name Getters for joint pose(s)
@@ -310,7 +310,7 @@ public:
   }
 
 protected:
-  bool computeCartesianPoses(EigenSTL::vector_Affine3d &poses) const;
+  bool computeCartesianPoses(EigenSTL::vector_Isometry3d &poses) const;
 
 protected:
   descartes_core::Frame tool_base_; /**<@brief Fixed transform from wrist/tool_plate to tool base. */

--- a/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
+++ b/descartes_trajectory/include/descartes_trajectory/joint_trajectory_pt.h
@@ -107,14 +107,14 @@ public:
 
   // TODO complete
   virtual bool getClosestCartPose(const std::vector<double> &seed_state, const descartes_core::RobotModel &model,
-                                  Eigen::Affine3d &pose) const;
+                                  Eigen::Isometry3d &pose) const;
 
   // TODO complete
   virtual bool getNominalCartPose(const std::vector<double> &seed_state, const descartes_core::RobotModel &model,
-                                  Eigen::Affine3d &pose) const;
+                                  Eigen::Isometry3d &pose) const;
 
   // TODO complete
-  virtual void getCartesianPoses(const descartes_core::RobotModel &model, EigenSTL::vector_Affine3d &poses) const;
+  virtual void getCartesianPoses(const descartes_core::RobotModel &model, EigenSTL::vector_Isometry3d &poses) const;
   /** @} (end section) */
 
   /**@name Getters for joint pose(s)

--- a/descartes_trajectory/src/axial_symmetric_pt.cpp
+++ b/descartes_trajectory/src/axial_symmetric_pt.cpp
@@ -9,7 +9,7 @@ static TolerancedFrame makeUnconstrainedRotation(double x, double y, double z, d
 {
   using namespace descartes_trajectory;
 
-  Eigen::Affine3d pose = toFrame(x, y, z, rx, ry, rz, EulerConventions::XYZ);
+  Eigen::Isometry3d pose = toFrame(x, y, z, rx, ry, rz, EulerConventions::XYZ);
   PositionTolerance pos_tol = ToleranceBase::zeroTolerance<PositionTolerance>(x, y, z);
   OrientationTolerance orient_tol = ToleranceBase::createSymmetric<OrientationTolerance>(
       ((axis == AxialSymmetricPt::X_AXIS) ? 0.0 : rx), ((axis == AxialSymmetricPt::Y_AXIS) ? 0.0 : ry),
@@ -18,7 +18,7 @@ static TolerancedFrame makeUnconstrainedRotation(double x, double y, double z, d
   return TolerancedFrame(pose, pos_tol, orient_tol);
 }
 
-static TolerancedFrame makeUnconstrainedRotation(const Eigen::Affine3d& pose, AxialSymmetricPt::FreeAxis axis)
+static TolerancedFrame makeUnconstrainedRotation(const Eigen::Isometry3d& pose, AxialSymmetricPt::FreeAxis axis)
 {
   using namespace descartes_trajectory;
 
@@ -54,7 +54,7 @@ AxialSymmetricPt::AxialSymmetricPt(double x, double y, double z, double rx, doub
 {
 }
 
-AxialSymmetricPt::AxialSymmetricPt(const Eigen::Affine3d& pose, double orient_increment, FreeAxis axis,
+AxialSymmetricPt::AxialSymmetricPt(const Eigen::Isometry3d& pose, double orient_increment, FreeAxis axis,
                                    const descartes_core::TimingConstraint& timing)
   : CartTrajectoryPt(makeUnconstrainedRotation(pose, axis),
                      0.0,               // The position discretization

--- a/descartes_trajectory/src/joint_trajectory_pt.cpp
+++ b/descartes_trajectory/src/joint_trajectory_pt.cpp
@@ -50,7 +50,7 @@ using namespace descartes_core;
 namespace descartes_trajectory
 {
 JointTrajectoryPt::JointTrajectoryPt(const descartes_core::TimingConstraint &timing)
-  : descartes_core::TrajectoryPt(timing), tool_(Eigen::Affine3d::Identity()), wobj_(Eigen::Affine3d::Identity())
+  : descartes_core::TrajectoryPt(timing), tool_(Eigen::Isometry3d::Identity()), wobj_(Eigen::Isometry3d::Identity())
 {
 }
 
@@ -63,7 +63,7 @@ JointTrajectoryPt::JointTrajectoryPt(const std::vector<TolerancedJointValue> &jo
 
 JointTrajectoryPt::JointTrajectoryPt(const std::vector<TolerancedJointValue> &joints,
                                      const descartes_core::TimingConstraint &timing)
-  : descartes_core::TrajectoryPt(timing), tool_(Eigen::Affine3d::Identity()), wobj_(Eigen::Affine3d::Identity())
+  : descartes_core::TrajectoryPt(timing), tool_(Eigen::Isometry3d::Identity()), wobj_(Eigen::Isometry3d::Identity())
 {
   unpackTolerancedJoints(joints, lower_, nominal_, upper_);
 }
@@ -73,24 +73,24 @@ JointTrajectoryPt::JointTrajectoryPt(const std::vector<double> &joints, const de
   , nominal_(joints)
   , lower_(joints)
   , upper_(joints)
-  , tool_(Eigen::Affine3d::Identity())
-  , wobj_(Eigen::Affine3d::Identity())
+  , tool_(Eigen::Isometry3d::Identity())
+  , wobj_(Eigen::Isometry3d::Identity())
 {
 }
 
 bool JointTrajectoryPt::getClosestCartPose(const std::vector<double> &, const RobotModel &,
-                                           Eigen::Affine3d &) const
+                                           Eigen::Isometry3d &) const
 {
   NOT_IMPLEMENTED_ERR(false)
 }
 
 bool JointTrajectoryPt::getNominalCartPose(const std::vector<double> &, const RobotModel &model,
-                                           Eigen::Affine3d &pose) const
+                                           Eigen::Isometry3d &pose) const
 {
   return model.getFK(nominal_, pose);
 }
 
-void JointTrajectoryPt::getCartesianPoses(const RobotModel &, EigenSTL::vector_Affine3d &poses) const
+void JointTrajectoryPt::getCartesianPoses(const RobotModel &, EigenSTL::vector_Isometry3d &poses) const
 {
   poses.clear();
 }


### PR DESCRIPTION
The most significant change is the replacement of the Eigen::Affine3d datatype for the Eigen::Isometry one (contributed in #235 ), which reflects a recent change in MoveIt.